### PR TITLE
Add COs

### DIFF
--- a/src/CommandingOfficers/Commander.java
+++ b/src/CommandingOfficers/Commander.java
@@ -201,9 +201,9 @@ public class Commander extends GameEventListener
   }
 
   /** Get the list of units this commander can build from the given property type. */
-  public ArrayList<UnitModel> getShoppingList(TerrainType buyLocation)
+  public ArrayList<UnitModel> getShoppingList(Location buyLocation)
   {
-    return (unitProductionByTerrain.get(buyLocation) != null) ? unitProductionByTerrain.get(buyLocation)
+    return (unitProductionByTerrain.get(buyLocation.getEnvironment().terrainType) != null) ? unitProductionByTerrain.get(buyLocation.getEnvironment().terrainType)
         : new ArrayList<UnitModel>();
   }
 

--- a/src/CommandingOfficers/Commander.java
+++ b/src/CommandingOfficers/Commander.java
@@ -45,7 +45,7 @@ public class Commander extends GameEventListener
   public ArrayList<Location> ownedProperties;
   public ArrayList<COModifier> modifiers;
   public Color myColor;
-  public static final int DEFAULTSTARTINGMONEY = 10000;
+  public static final int DEFAULTSTARTINGMONEY = 0;
   public static final int CHARGERATIO_FUNDS = 9000; // quantity of funds damage to equal 1 unit of power charge
   public static final int CHARGERATIO_HP = 90; // quantity of HP damage dealt to equal 1 unit of power charge
   public int money = 0;
@@ -249,7 +249,7 @@ public class Commander extends GameEventListener
   public void activateAbility(CommanderAbility ability)
   {
     modifyAbilityPower(-ability.getCost());
-    myActiveAbilityName = ability.myName;
+    myActiveAbilityName = ability.toString();
   }
 
   protected void modifyAbilityPower(double amount)
@@ -299,9 +299,9 @@ public class Commander extends GameEventListener
     {
       double power = 0;
       // Add up the funds value of the damage done to both participants.
-      power += myHPLoss / minion.model.maxHP * minion.model.moneyCost;
+      power += myHPLoss / minion.model.maxHP * minion.model.getCost();
       // The damage we deal is worth half as much as the damage we take, to help powers be a comeback mechanic.
-      power += myHPDealt / enemy.model.maxHP * enemy.model.moneyCost / 2;
+      power += myHPDealt / enemy.model.maxHP * enemy.model.getCost() / 2;
       power /= CHARGERATIO_FUNDS; // Turn funds into units of power
       power += myHPDealt / CHARGERATIO_HP; // Add power based on HP damage dealt; rewards aggressiveness.
 

--- a/src/CommandingOfficers/CommanderAbility.java
+++ b/src/CommandingOfficers/CommanderAbility.java
@@ -5,7 +5,7 @@ import Terrain.GameMap;
 public abstract class CommanderAbility
 {
   public final Commander myCommander;
-  public final String myName;
+  protected String myName;
   private int myPowerCost;
 
   public CommanderAbility(Commander commander, String abilityName, int powerCost)

--- a/src/CommandingOfficers/CommanderBear_Bull.java
+++ b/src/CommandingOfficers/CommanderBear_Bull.java
@@ -28,18 +28,19 @@ public class CommanderBear_Bull extends Commander
     incomeBase = incomePerCity;
     // we start in Bear mode, so swap to it at the start
     isBull = true;
-    swapD2Ds();
+    swapD2Ds(true);
 
     addCommanderAbility(new UpDownTurnAbility(this));
     addCommanderAbility(new BustBoomAbility(this));
   }
 
-  public void swapD2Ds()
+  public void swapD2Ds(boolean setIncome)
   {
     if( isBull )
     {
       isBull = false;
-      incomePerCity = (int) (incomeBase * BEAR_MOD);
+      if( setIncome )
+        incomePerCity = (int) (incomeBase * BEAR_MOD);
       for( UnitModel um : unitModels )
       {
         um.COcost = BEAR_MOD;
@@ -48,7 +49,8 @@ public class CommanderBear_Bull extends Commander
     else
     {
       isBull = true;
-      incomePerCity = (int) (incomeBase * BULL_MOD);
+      if( setIncome )
+        incomePerCity = (int) (incomeBase * BULL_MOD);
       for( UnitModel um : unitModels )
       {
         um.COcost = BULL_MOD;
@@ -59,13 +61,15 @@ public class CommanderBear_Bull extends Commander
   /**
    * Down/UpTurn swaps D2Ds for this turn.
    * All units on a property you own take 3HP mass damage and you gain the funds value of that HP.
+   * Bear: Gives you a fast injection of funds based on 1.2x your liquidated units' HP value. Should probably build before using.
+   * Bull: Having units on properties when you use it is poor due to the 0.9x liquidation price, however, the discount should be welcome.
    */
   private static class UpDownTurnAbility extends CommanderAbility implements COModifier
   {
     private static final String UPTURN_NAME = "UpTurn";
     private static final String DOWNTURN_NAME = "DownTurn";
     private static final int DOWNUPTURN_COST = 3;
-    private static final int DOWNUPTURN_DAMAGE = -3;
+    private static final int DOWNUPTURN_LIQUIDATION = -3;
     CommanderBear_Bull COcast;
 
     UpDownTurnAbility(Commander commander)
@@ -92,7 +96,7 @@ public class CommanderBear_Bull extends Commander
     public void apply(Commander commander)
     {
       CommanderBear_Bull cmdr = (CommanderBear_Bull) commander;
-      cmdr.swapD2Ds();
+      cmdr.swapD2Ds(false);
       // Damage is dealt after swapping D2Ds so it's actually useful to Bear
       for( Location loc : cmdr.ownedProperties )
       {
@@ -101,7 +105,7 @@ public class CommanderBear_Bull extends Commander
           Unit victim = loc.getResident();
           if( null != victim )
           {
-            double delta = victim.alterHP(DOWNUPTURN_DAMAGE);
+            double delta = victim.alterHP(DOWNUPTURN_LIQUIDATION);
             cmdr.money += (-1 * delta * victim.model.getCost()) / 10;
           }
         }
@@ -112,7 +116,7 @@ public class CommanderBear_Bull extends Commander
     public void revert(Commander commander)
     {
       CommanderBear_Bull cmdr = (CommanderBear_Bull) commander;
-      cmdr.swapD2Ds();
+      cmdr.swapD2Ds(true);
     }
   }
 
@@ -165,7 +169,7 @@ public class CommanderBear_Bull extends Commander
     {
       // Next turn, we swap D2Ds permanently
       CommanderBear_Bull cmdr = (CommanderBear_Bull) commander;
-      cmdr.swapD2Ds();
+      cmdr.swapD2Ds(true);
     }
   }
 

--- a/src/CommandingOfficers/CommanderBear_Bull.java
+++ b/src/CommandingOfficers/CommanderBear_Bull.java
@@ -1,0 +1,176 @@
+package CommandingOfficers;
+
+import CommandingOfficers.Modifiers.COModifier;
+import Terrain.GameMap;
+import Terrain.Location;
+import Units.Unit;
+import Units.UnitModel;
+
+/*
+ * The Bear & Bull is a dual-CO that sorta models an economy.
+ * In Bear mode, he gets less income and also pays less for troops.
+ * In Bull mode, he gets more and pays more.
+ * His powers let him toggle between these to maximize his gainz.
+ */
+public class CommanderBear_Bull extends Commander
+{
+  private static final CommanderInfo coInfo = new CommanderInfo("Bear&Bull", CommanderLibrary.CommanderEnum.BEAR_BULL);
+  private final int incomeBase;
+  public boolean isBull;
+
+  private final double BEAR_MOD = 0.9;
+  private final double BULL_MOD = 1.2;
+
+  public CommanderBear_Bull()
+  {
+    super(coInfo);
+
+    incomeBase = incomePerCity;
+    // we start in Bear mode, so swap to it at the start
+    isBull = true;
+    swapD2Ds();
+
+    addCommanderAbility(new UpDownTurnAbility(this));
+    addCommanderAbility(new BustBoomAbility(this));
+  }
+
+  public void swapD2Ds()
+  {
+    if( isBull )
+    {
+      isBull = false;
+      incomePerCity = (int) (incomeBase * BEAR_MOD);
+      for( UnitModel um : unitModels )
+      {
+        um.COcost = BEAR_MOD;
+      }
+    }
+    else
+    {
+      isBull = true;
+      incomePerCity = (int) (incomeBase * BULL_MOD);
+      for( UnitModel um : unitModels )
+      {
+        um.COcost = BULL_MOD;
+      }
+    }
+  }
+
+  /**
+   * Down/UpTurn swaps D2Ds for this turn.
+   * All units on a property you own take 3HP mass damage and you gain the funds value of that HP.
+   */
+  private static class UpDownTurnAbility extends CommanderAbility implements COModifier
+  {
+    private static final String UPTURN_NAME = "UpTurn";
+    private static final String DOWNTURN_NAME = "DownTurn";
+    private static final int DOWNUPTURN_COST = 3;
+    private static final int DOWNUPTURN_DAMAGE = -3;
+    CommanderBear_Bull COcast;
+
+    UpDownTurnAbility(Commander commander)
+    {
+      // as we start in Bear form, UpTurn is the correct starting name
+      super(commander, UPTURN_NAME, DOWNUPTURN_COST);
+      COcast = (CommanderBear_Bull) commander;
+    }
+
+    @Override
+    public String toString()
+    {
+      myName = (COcast.isBull) ? DOWNTURN_NAME : UPTURN_NAME;
+      return myName;
+    }
+
+    @Override
+    protected void perform(GameMap gameMap)
+    {
+      myCommander.addCOModifier(this);
+    }
+
+    @Override // COModifier interface.
+    public void apply(Commander commander)
+    {
+      CommanderBear_Bull cmdr = (CommanderBear_Bull) commander;
+      cmdr.swapD2Ds();
+      // Damage is dealt after swapping D2Ds so it's actually useful to Bear
+      for( Location loc : cmdr.ownedProperties )
+      {
+        if( loc.getOwner() == myCommander )
+        {
+          Unit victim = loc.getResident();
+          if( null != victim )
+          {
+            double delta = victim.alterHP(DOWNUPTURN_DAMAGE);
+            cmdr.money += (-1 * delta * victim.model.getCost()) / 10;
+          }
+        }
+      }
+    }
+
+    @Override
+    public void revert(Commander commander)
+    {
+      CommanderBear_Bull cmdr = (CommanderBear_Bull) commander;
+      cmdr.swapD2Ds();
+    }
+  }
+
+  /**
+   * Boom/Bust reduces costs by 20% (to 70% or 100%). Swap D2Ds permanently when this wears off.
+   * In the future, it'd be cool to be able to build on valid locations next to production facilities... but that's hard and I'm lazy
+   * For clarification: Boom is Bear's ability; Bust is Bull's
+   */
+  private static class BustBoomAbility extends CommanderAbility implements COModifier
+  {
+    private static final String BUST_NAME = "Bust";
+    private static final String BOOM_NAME = "Boom";
+    private static final int BOOMBUST_COST = 6;
+    private static final double BOOMBUST_BUFF = 0.2;
+    CommanderBear_Bull COcast;
+
+    BustBoomAbility(Commander commander)
+    {
+      // as we start in Bear form, UpTurn is the correct starting name
+      super(commander, BOOM_NAME, BOOMBUST_COST);
+      COcast = (CommanderBear_Bull) commander;
+    }
+
+    @Override
+    public String toString()
+    {
+      myName = (COcast.isBull) ? BUST_NAME : BOOM_NAME;
+      return myName;
+    }
+
+    @Override
+    protected void perform(GameMap gameMap)
+    {
+      myCommander.addCOModifier(this);
+    }
+
+    @Override // COModifier interface.
+    public void apply(Commander commander)
+    {
+      CommanderBear_Bull cmdr = (CommanderBear_Bull) commander;
+      // Instead of swapping, we get a discount. Yaaaay.
+      for( UnitModel um : cmdr.unitModels )
+      {
+        um.COcost -= BOOMBUST_BUFF;
+      }
+    }
+
+    @Override
+    public void revert(Commander commander)
+    {
+      // Next turn, we swap D2Ds permanently
+      CommanderBear_Bull cmdr = (CommanderBear_Bull) commander;
+      cmdr.swapD2Ds();
+    }
+  }
+
+  public static CommanderInfo getInfo()
+  {
+    return coInfo;
+  }
+}

--- a/src/CommandingOfficers/CommanderCinder.java
+++ b/src/CommandingOfficers/CommanderCinder.java
@@ -1,0 +1,181 @@
+package CommandingOfficers;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import CommandingOfficers.Modifiers.COModifier;
+import Engine.XYCoord;
+import Engine.Combat.BattleSummary;
+import Engine.GameEvents.GameEventListener;
+import Terrain.GameMap;
+import Terrain.Location;
+import Units.Unit;
+import Units.UnitModel;
+
+/*
+ * Cinder is based on getting an edge in the action economy, at the cost of unit health.
+ */
+public class CommanderCinder extends Commander
+{
+  private static final CommanderInfo coInfo = new CommanderInfo("Cinder", CommanderLibrary.CommanderEnum.CINDER);
+
+  private static final double COST_MOD_PER_BUILD = 1.2;
+
+  private HashMap<XYCoord, Integer> buildCounts = new HashMap<>();
+
+  public CommanderCinder()
+  {
+    super(coInfo);
+
+    addCommanderAbility(new SearAbility(this));
+    addCommanderAbility(new WitchFireAbility(this));
+  }
+
+  public static CommanderInfo getInfo()
+  {
+    return coInfo;
+  }
+
+  @Override
+  /** Get the list of units this commander can build from the given property type. */
+  public ArrayList<UnitModel> getShoppingList(Location buyLocation)
+  {
+    setPrices(buildCounts.get(buyLocation.getCoordinates()));
+    return super.getShoppingList(buyLocation);
+  }
+
+  /*
+   * Cinder builds units at 8HP ready to act.
+   * To compensate for the ability to continue producing units in a single turn,
+   * the cost of units increases exponentially for repeated purchases from a single property.
+   */
+  public void receiveCreateUnitEvent(Unit unit)
+  {
+    if( this == unit.CO )
+    {
+      XYCoord buildCoords = new XYCoord(unit.x, unit.y);
+      buildCounts.put(buildCoords, buildCounts.get(buildCoords) + 1);
+      setPrices(0);
+
+      unit.alterHP(-2);
+      unit.isTurnOver = false;
+    }
+  }
+
+  /*
+   * Purchase price problems reset at the start of turn.
+   */
+  @Override
+  public void initTurn(GameMap map)
+  {
+    for( Location loc : ownedProperties )
+    {
+      buildCounts.put(loc.getCoordinates(), 0);
+    }
+    setPrices(0);
+    super.initTurn(map);
+  }
+
+  public void setPrices(int repetitons)
+  {
+    for( UnitModel um : unitModels )
+    {
+      um.COcost = Math.pow(COST_MOD_PER_BUILD, repetitons);
+    }
+  }
+
+  /*
+   * Sear causes 1 mass damage to Cinder's own troops, in exchange for refreshing them.
+   */
+  private static class SearAbility extends CommanderAbility
+  {
+    private static final String SEAR_NAME = "Sear";
+    private static final int SEAR_COST = 5;
+    private static final int SEAR_WOUND = -1;
+
+    SearAbility(Commander commander)
+    {
+      super(commander, SEAR_NAME, SEAR_COST);
+    }
+
+    @Override
+    protected void perform(GameMap gameMap)
+    {
+      for( Unit unit : myCommander.units )
+      {
+        unit.alterHP(SEAR_WOUND);
+        unit.isTurnOver = false;
+      }
+    }
+  }
+
+  /*
+   * Witchfire causes Cinder's troops to automatically refresh after attacking, at the cost of 1 HP
+   */
+  private static class WitchFireAbility extends CommanderAbility implements COModifier
+  {
+    private static final String WITCHFIRE_NAME = "Witchfire";
+    private static final int WITCHFIRE_COST = 9;
+    private static final int WITCHFIRE_WOUND = -1;
+    private WitchFireListener listener;
+
+    WitchFireAbility(Commander commander)
+    {
+      // as we start in Bear form, UpTurn is the correct starting name
+      super(commander, WITCHFIRE_NAME, WITCHFIRE_COST);
+      listener = new WitchFireListener(commander, WITCHFIRE_WOUND);
+    }
+
+    @Override
+    protected void perform(GameMap gameMap)
+    {
+      myCommander.addCOModifier(this);
+    }
+
+    @Override // COModifier interface.
+    public void apply(Commander commander)
+    {
+      GameEventListener.registerEventListener(listener);
+    }
+
+    @Override
+    public void revert(Commander commander)
+    {
+      GameEventListener.unregisterEventListener(listener);
+    }
+  }
+
+  private static class WitchFireListener extends GameEventListener
+  {
+    private Commander myCommander = null;
+    private final int refreshCost;
+
+    public WitchFireListener(Commander myCo, int refreshWound)
+    {
+      myCommander = myCo;
+      refreshCost = refreshWound;
+    }
+
+    @Override
+    public void receiveBattleEvent(BattleSummary battleInfo)
+    {
+      // Determine if we were part of this fight. If so, refresh at our own expense
+      if( battleInfo.attacker.CO == myCommander )
+      {
+        if( battleInfo.attacker.getPreciseHP() > 0 )
+        {
+          battleInfo.attacker.alterHP(refreshCost);
+          battleInfo.attacker.isTurnOver = false;
+        }
+      }
+      else if( battleInfo.defender.CO == myCommander )
+      {
+        if( battleInfo.defender.getPreciseHP() > 0 )
+        {
+          battleInfo.defender.alterHP(refreshCost);
+          battleInfo.defender.isTurnOver = false;
+        }
+      }
+    }
+  }
+}

--- a/src/CommandingOfficers/CommanderLibrary.java
+++ b/src/CommandingOfficers/CommanderLibrary.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 
 public class CommanderLibrary
 {
-  public enum CommanderEnum { STRONG, LION, PATCH, NOONE };
+  public enum CommanderEnum { STRONG, LION, BEAR_BULL, PATCH, NOONE };
   
   private static ArrayList<CommanderInfo> commanderList = null;
 
@@ -23,6 +23,7 @@ public class CommanderLibrary
     commanderList = new ArrayList<CommanderInfo>();
     commanderList.add( CommanderStrong.getInfo() );
     commanderList.add( CommanderPatch.getInfo() );
+    commanderList.add( CommanderBear_Bull.getInfo() );
   }
 
   public static Commander makeCommander( CommanderInfo info, Color color )
@@ -34,6 +35,9 @@ public class CommanderLibrary
         co = new CommanderStrong();
         break;
       case LION: // TODO
+        break;
+      case BEAR_BULL:
+        co = new CommanderBear_Bull();
         break;
       case PATCH:
         co = new CommanderPatch(); // TODO

--- a/src/CommandingOfficers/CommanderLibrary.java
+++ b/src/CommandingOfficers/CommanderLibrary.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 
 public class CommanderLibrary
 {
-  public enum CommanderEnum { STRONG, LION, BEAR_BULL, PATCH, NOONE };
+  public enum CommanderEnum { STRONG, LION, BEAR_BULL, PATCH, CINDER, NOONE };
   
   private static ArrayList<CommanderInfo> commanderList = null;
 
@@ -24,6 +24,7 @@ public class CommanderLibrary
     commanderList.add( CommanderStrong.getInfo() );
     commanderList.add( CommanderPatch.getInfo() );
     commanderList.add( CommanderBear_Bull.getInfo() );
+    commanderList.add( CommanderCinder.getInfo() );
   }
 
   public static Commander makeCommander( CommanderInfo info, Color color )
@@ -41,6 +42,9 @@ public class CommanderLibrary
         break;
       case PATCH:
         co = new CommanderPatch(); // TODO
+        break;
+      case CINDER:
+        co = new CommanderCinder();
         break;
       case NOONE:
         default:

--- a/src/CommandingOfficers/CommanderPatch.java
+++ b/src/CommandingOfficers/CommanderPatch.java
@@ -136,12 +136,12 @@ public class CommanderPatch extends Commander
       if( battleInfo.attacker.CO == myCommander )
       {
         hpLoss = battleInfo.defenderHPLoss;
-        unitCost = battleInfo.defender.model.moneyCost;
+        unitCost = battleInfo.defender.model.getCost();
       }
       else if( battleInfo.defender.CO == myCommander )
       {
         hpLoss = battleInfo.attackerHPLoss;
-        unitCost = battleInfo.attacker.model.moneyCost;
+        unitCost = battleInfo.attacker.model.getCost();
       }
 
       // Do the necessary math, then round to the nearest int.

--- a/src/Engine/GameAction.java
+++ b/src/Engine/GameAction.java
@@ -164,7 +164,7 @@ public interface GameAction
       buildLocation = where;
       boolean isValid = true;
       isValid &= (null != gameMap) && (null != who) && (null != what) && (null != where);
-      isValid &= (who.money >= what.moneyCost);
+      isValid &= (who.money >= what.getCost());
 
       if( isValid )
       {

--- a/src/Engine/GameEvents/CreateUnitEvent.java
+++ b/src/Engine/GameEvents/CreateUnitEvent.java
@@ -19,7 +19,7 @@ public class CreateUnitEvent implements GameEvent
     myBuildCoords = coords;
 
     // TODO: Consider breaking the fiscal part into its own event.
-    if( model.moneyCost <= commander.money )
+    if( model.getCost() <= commander.money )
     {
       myNewUnit = new Unit(myCommander, model);
     }
@@ -50,7 +50,7 @@ public class CreateUnitEvent implements GameEvent
   {
     if( null != myNewUnit )
     {
-      myCommander.money -= myNewUnit.model.moneyCost;
+      myCommander.money -= myNewUnit.model.getCost();
       myCommander.units.add(myNewUnit);
       gameMap.addNewUnit(myNewUnit, myBuildCoords.xCoord, myBuildCoords.yCoord);
     }

--- a/src/Engine/GameInput/DefaultState.java
+++ b/src/Engine/GameInput/DefaultState.java
@@ -41,10 +41,10 @@ class DefaultState extends GameInputState<XYCoord>
       myStateData.unitActor = resident;
       next = new SelectMoveLocation(myStateData);
     }
-    else if( (null == resident) && (loc.getOwner() == myStateData.commander) && myStateData.commander.getShoppingList(loc.getEnvironment().terrainType).size() > 0 )
+    else if( (null == resident) && (loc.getOwner() == myStateData.commander) && myStateData.commander.getShoppingList(loc).size() > 0 )
     {
       // We are considering a new unit purchase.
-      ArrayList<UnitModel> buildables = myStateData.commander.getShoppingList(loc.getEnvironment().terrainType);
+      ArrayList<UnitModel> buildables = myStateData.commander.getShoppingList(loc);
       myStateData.menuOptions = buildables;
       next = new SelectUnitProduction(myStateData, buildables, coord);
     }

--- a/src/Engine/Utils.java
+++ b/src/Engine/Utils.java
@@ -384,7 +384,7 @@ public class Utils
         // TODO: maybe calculate whether the CO has enough money to buy something at this industry
         if( null == resident && loc.getOwner() == co )
         {
-          if( co.getShoppingList(loc.getEnvironment().terrainType).size() > 0 )
+          if( co.getShoppingList(loc).size() > 0 )
           {
             industries.add(loc.getCoordinates());
           }

--- a/src/Test/TestGameEvent.java
+++ b/src/Test/TestGameEvent.java
@@ -137,7 +137,7 @@ public class TestGameEvent extends TestCase
     boolean testPassed = true;
 
     XYCoord coords = new XYCoord(13, 8);
-    int startFunds = testCo1.money;
+    int startFunds = testCo1.money = 9001;
     CreateUnitEvent event = new CreateUnitEvent(testCo1, testCo1.getUnitModel(UnitEnum.INFANTRY), coords);
 
     testPassed &= validate(testMap.getLocation(coords).getResident() == null, "    Location is already occupied.");
@@ -149,7 +149,7 @@ public class TestGameEvent extends TestCase
     testPassed &= validate(resident.model.type == UnitEnum.INFANTRY, "    Unit created with wrong type.");
     testPassed &= validate(resident.CO == testCo1, "    Unit created with wrong type.");
     // TODO: Consider moving cost into a new TransferFundsEvent.
-    testPassed &= validate(testCo1.money == (startFunds - resident.model.moneyCost), "    Unit cost not accounted correctly.");
+    testPassed &= validate(testCo1.money == (startFunds - resident.model.getCost()), "    Unit cost not accounted correctly.");
 
     // Clean up.
     testMap.removeUnit(resident);

--- a/src/UI/InGameProductionMenu.java
+++ b/src/UI/InGameProductionMenu.java
@@ -72,7 +72,7 @@ public class InGameProductionMenu extends InGameMenu<UnitModel>
       }
       else
       {
-        price = model.moneyCost;
+        price = model.getCost();
       }
 
       // Pad the price with an extra space if it is only four digits.

--- a/src/Units/Unit.java
+++ b/src/Units/Unit.java
@@ -96,7 +96,7 @@ public class Unit
         if( HP < model.maxHP )
         {
           int neededHP = Math.min(model.maxHP - getHP(), 2); // will be 0, 1, 2
-          double proportionalCost = model.moneyCost / model.maxHP;
+          double proportionalCost = model.getCost() / model.maxHP;
           if( CO.money >= neededHP * proportionalCost )
           {
             CO.money -= neededHP * proportionalCost;
@@ -200,11 +200,13 @@ public class Unit
       HP = 0;
     }
   }
-  public void alterHP(int change)
+  public double alterHP(int change)
   {
+    double before = HP;
     // Change the unit's health, but don't grant more
     // than 10 HP, and don't drop HP to zero.
     HP = Math.max(1, Math.min(10, getHP() + change));
+    return HP - before;
   }
 
   public void capture(Location target)

--- a/src/Units/UnitModel.java
+++ b/src/Units/UnitModel.java
@@ -31,7 +31,7 @@ public class UnitModel
   public String name;
   public UnitEnum type;
   public ChassisEnum chassis;
-  public int moneyCost = 9001;
+  private int moneyCost = 9001;
   public int maxFuel;
   public int idleFuelBurn;
   public int movePower;
@@ -45,6 +45,7 @@ public class UnitModel
   public Vector<UnitEnum> holdables;
   private int COstr;
   private int COdef;
+  public double COcost = 1.0;
 
   public UnitModel(String pName, UnitEnum pType, ChassisEnum pChassis, int cost, int pFuelMax, int pIdleFuelBurn, int pMovePower, MoveType pPropulsion,
       ActionType[] actions, WeaponModel[] weapons)
@@ -95,7 +96,7 @@ public class UnitModel
     }
 
     // Create a new model with the given attributes.
-    UnitModel newModel = new UnitModel(other.name, other.type, other.chassis, other.moneyCost, other.maxFuel, other.idleFuelBurn,
+    UnitModel newModel = new UnitModel(other.name, other.type, other.chassis, other.getCost(), other.maxFuel, other.idleFuelBurn,
         other.movePower, new MoveType(other.propulsion), other.possibleActions, weaponModels);
 
     // Duplicate the other model's transporting abilities.
@@ -103,6 +104,11 @@ public class UnitModel
     newModel.holdables.addAll(other.holdables);
 
     return newModel;
+  }
+  
+  public int getCost()
+  {
+    return (int) (moneyCost*COcost);
   }
 
   /**


### PR DESCRIPTION
Adds two of my pet ideas that I've been tossing around for a while.
Bear & Bull's COP would interact weirdly with Cinder if Cinder opened a build menu without building anything, but I'm not sure at this point how to fix that.

I had to make some changes to other stuff to support their abilities...
Unit cost itself being unmodifiable makes sense, though I can see potential use cases. Having a multiplier with free access seems truer to how AW COs typically work, though.
The change to getShoppingList()'s arguments make sense, and actually reduce code size by a small amount.
Change to AlterHP doesn't hurt anything, and is useful.