### PR TITLE
Witchfire will now execute units that end their turn with one HP.

### DIFF
--- a/src/CommandingOfficers/Commander.java
+++ b/src/CommandingOfficers/Commander.java
@@ -12,6 +12,7 @@ import Engine.XYCoord;
 import Engine.Combat.BattleInstance;
 import Engine.Combat.BattleSummary;
 import Engine.GameEvents.GameEventListener;
+import Engine.GameEvents.GameEventQueue;
 import Terrain.GameMap;
 import Terrain.Location;
 import Terrain.TerrainType;
@@ -175,6 +176,12 @@ public class Commander extends GameEventListener
       aiController.initTurn(map);
     }
   }
+
+  /**
+   * This is called after every GameAction, and between turns, and allows Commanders to inject
+   * events that don't arise via normal gameplay. Most Commanders should not need to override this.
+   */
+  public void pollForEvents(GameEventQueue eventsOut) {}
 
   /**
    * @return whether these COs would like to kill each other

--- a/src/CommandingOfficers/CommanderCinder.java
+++ b/src/CommandingOfficers/CommanderCinder.java
@@ -7,6 +7,8 @@ import CommandingOfficers.Modifiers.COModifier;
 import Engine.XYCoord;
 import Engine.Combat.BattleSummary;
 import Engine.GameEvents.GameEventListener;
+import Engine.GameEvents.GameEventQueue;
+import Engine.GameEvents.UnitDieEvent;
 import Terrain.GameMap;
 import Terrain.Location;
 import Units.Unit;
@@ -22,6 +24,8 @@ public class CommanderCinder extends Commander
   private static final double COST_MOD_PER_BUILD = 1.2;
 
   private HashMap<XYCoord, Integer> buildCounts = new HashMap<>();
+
+  private GameEventQueue pollEvents = new GameEventQueue();
 
   public CommanderCinder()
   {
@@ -76,10 +80,18 @@ public class CommanderCinder extends Commander
     super.initTurn(map);
   }
 
+  @Override
   public void endTurn()
   {
     setPrices(0);
     super.endTurn();
+  }
+
+  @Override
+  public void pollForEvents(GameEventQueue eventsOut)
+  {
+    eventsOut.addAll(pollEvents);
+    pollEvents.clear();
   }
 
   public void setPrices(int repetitons)
@@ -178,6 +190,14 @@ public class CommanderCinder extends Commander
           minion.alterHP(-refreshCost);
           minion.isTurnOver = false;
           // TODO: It'd be cool if we could kill the unit here, so Cinder can eke out maximal use without cheating.
+        }
+        else
+        {
+          // Guess he's not gonna make it.
+          // TODO: Maybe add a debuff event/animation here as well.
+          UnitDieEvent event = new UnitDieEvent(minion);
+          CommanderCinder Cinder = (CommanderCinder)myCommander;
+          Cinder.pollEvents.add(event);
         }
       }
     }

--- a/src/Engine/MapController.java
+++ b/src/Engine/MapController.java
@@ -4,6 +4,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Queue;
 
+import CommandingOfficers.Commander;
 import Engine.GameEvents.GameEvent;
 import Engine.GameEvents.GameEventListener;
 import Engine.GameEvents.GameEventQueue;
@@ -532,6 +533,18 @@ public class MapController implements IController, GameInputHandler.StateChanged
       Unit u = unitsToInit.poll();
       GameEventQueue events = u.initTurn(myGame.gameMap);
       myView.animate(events);
+    }
+
+    for( Commander co : myGame.commanders )
+    {
+      GameEventQueue events = new GameEventQueue();
+      co.pollForEvents(events);
+      if( !events.isEmpty() )
+      {
+        animEventQueueIsEmpty = false;
+        myView.animate(events);
+        break; // We'll get the next commander the next time we hit this block.
+      }
     }
 
     // If we are done animating the last action, check to see if the game is over.

--- a/src/Engine/MapController.java
+++ b/src/Engine/MapController.java
@@ -535,15 +535,18 @@ public class MapController implements IController, GameInputHandler.StateChanged
       myView.animate(events);
     }
 
-    for( Commander co : myGame.commanders )
+    if( animEventQueueIsEmpty )
     {
-      GameEventQueue events = new GameEventQueue();
-      co.pollForEvents(events);
-      if( !events.isEmpty() )
+      for( Commander co : myGame.commanders )
       {
-        animEventQueueIsEmpty = false;
-        myView.animate(events);
-        break; // We'll get the next commander the next time we hit this block.
+        GameEventQueue events = new GameEventQueue();
+        co.pollForEvents(events);
+        if( !events.isEmpty() )
+        {
+          animEventQueueIsEmpty = false;
+          myView.animate(events);
+          break; // We'll get the next commander the next time we hit this block.
+        }
       }
     }
 


### PR DESCRIPTION
If you want Witchfire to execute one-HP units, here's one way to make that happen. It does sort of open a can of worms in terms of what's possible, but we've also been operating in a "more flexibility is better" paradigm, so I can't say I'm opposed to making this change.
I thought about implementing the "Just publish an extra event right after the battle ends" approach, but I'm not a fan of that one, since that would bypass the animator.

This does of course break with tradition in *ahem* similar games, in terms of killing units outside of combat, but I'm not sure I'll shed tears over that either.

I don't have a strong opinion either way; let me know what you prefer, and of course, if you have a better option, do tell.