### PR TITLE
Fixes #143 - Units can no longer one-two punch HQs from another property

### DIFF
--- a/src/Engine/GameEvents/CaptureEvent.java
+++ b/src/Engine/GameEvents/CaptureEvent.java
@@ -1,5 +1,6 @@
 package Engine.GameEvents;
 
+import Engine.XYCoord;
 import Terrain.GameMap;
 import Terrain.Location;
 import UI.MapView;
@@ -17,9 +18,10 @@ public class CaptureEvent implements GameEvent
   {
     unit = u;
     location = loc;
+    XYCoord unitXY = new XYCoord(u.x, u.y);
     if( null != location && location.isCaptureable() && unit.CO.isEnemy(location.getOwner()) )
     {
-      priorCaptureAmount = unit.getCaptureProgress();
+      priorCaptureAmount = (unitXY.equals(location.getCoordinates()) ? unit.getCaptureProgress() : 0);
       captureAmount = unit.getHP(); // TODO: Apply CO buffs.
     }
     else


### PR DESCRIPTION
I kinda prefer to capture progress in Unit, at least for now - it's the less invasive change, and it may play better with COs who have a different capture rate.

I'm also leery of putting important info into Locations, since they are somewhat ephemeral now that `MapWindow` can invent them.