### PR TITLE
Weather queuing

### DIFF
--- a/src/Engine/GameEvents/GameEventListener.java
+++ b/src/Engine/GameEvents/GameEventListener.java
@@ -1,10 +1,13 @@
 package Engine.GameEvents;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Set;
 import java.util.WeakHashMap;
 
 import Engine.Combat.BattleSummary;
+import Engine.GameEvents.MapChangeEvent.EnvironmentAssignment;
+import Terrain.Environment.Weathers;
 import Terrain.Location;
 import Units.Unit;
 
@@ -56,6 +59,7 @@ public abstract class GameEventListener
   }
 
   // The functions below should be overridden by subclasses for event types they care about.
+  // As a rule, we should avoid passing the actual event to the receive hooks when possible.
   public void receiveBattleEvent(BattleSummary summary){};
   public void receiveCreateUnitEvent(Unit unit){};
   public void receiveCaptureEvent(Unit unit, Location location){};
@@ -65,5 +69,6 @@ public abstract class GameEventListener
   public void receiveResupplyEvent(ResupplyEvent event){};
   public void receiveUnitDieEvent(UnitDieEvent event){};
   public void receiveUnloadEvent(UnloadEvent event){};
-  public void receiveMapChangeEvent(MapChangeEvent event){};
+  public void receiveTerrainChangeEvent(ArrayList<EnvironmentAssignment> terrainChanges){};
+  public void receiveWeatherChangeEvent(Weathers weather, int duration){};
 }

--- a/src/Engine/GameEvents/GlobalWeatherEvent.java
+++ b/src/Engine/GameEvents/GlobalWeatherEvent.java
@@ -1,0 +1,67 @@
+package Engine.GameEvents;
+
+import Engine.XYCoord;
+import Terrain.Environment.Weathers;
+import Terrain.Location;
+import Terrain.MapMaster;
+import UI.MapView;
+import UI.Art.Animation.GameAnimation;
+
+/**
+ * This event changes the weather of the whole map.
+ */
+public class GlobalWeatherEvent implements GameEvent
+{
+  private Weathers weather;
+  private int duration;
+
+  /** Changes the whole map to the given weather. */
+  public GlobalWeatherEvent(Weathers newWeather)
+  {
+    this(newWeather, 1);
+  }
+
+  /** Changes the weather for the given number of rounds. */
+  public GlobalWeatherEvent(Weathers newWeather, int forecastDuration)
+  {
+    weather = newWeather;
+    duration = forecastDuration; 
+  }
+
+  @Override
+  public GameAnimation getEventAnimation(MapView mapView)
+  {
+    return null;
+  }
+
+  @Override
+  public void sendToListener(GameEventListener listener)
+  {
+    listener.receiveWeatherChangeEvent(weather, duration);
+  }
+
+  @Override
+  public void performEvent(MapMaster gameMap)
+  {
+    for( int y = 0; y < gameMap.mapHeight; ++y )
+    {
+      for( int x = 0; x < gameMap.mapWidth; ++x )
+      {
+        Location loc = gameMap.getLocation(x, y);
+        loc.setForecast(weather, (gameMap.commanders.length * duration) - 1);
+      }
+    }
+  }
+
+  @Override
+  public XYCoord getStartPoint()
+  {
+    return null;
+  }
+
+  @Override
+  public XYCoord getEndPoint()
+  {
+    return null;
+  }
+}

--- a/src/Engine/GameEvents/MapChangeEvent.java
+++ b/src/Engine/GameEvents/MapChangeEvent.java
@@ -2,6 +2,7 @@ package Engine.GameEvents;
 
 import Engine.XYCoord;
 import Terrain.Environment;
+import Terrain.Location;
 import Terrain.MapMaster;
 import UI.MapView;
 import UI.Art.Animation.GameAnimation;
@@ -13,10 +14,26 @@ public class MapChangeEvent implements GameEvent
 {
   private XYCoord where;
   private Environment myEnvironment;
+  private int turns;
+
+  /** For when you just want to redraw the map */
+  public MapChangeEvent()
+  {
+    this(null, null, 0);
+  }
+
+  /** For changing terrain type */
   public MapChangeEvent(XYCoord location, Environment newTile)
+  {
+    this(location, newTile, 0);
+  }
+
+  /** For changing weather */
+  public MapChangeEvent(XYCoord location, Environment newTile, int duration)
   {
     where = location;
     myEnvironment = newTile;
+    turns = duration;
   }
 
   @Override
@@ -34,7 +51,13 @@ public class MapChangeEvent implements GameEvent
   @Override
   public void performEvent(MapMaster gameMap)
   {
-    gameMap.getLocation(where).setEnvironment(myEnvironment);
+    Location loc = gameMap.getLocation(where);
+    if( null != loc )
+    {
+      loc.setEnvironment(myEnvironment);
+      if (turns > 0)
+        loc.setForecast(myEnvironment.weatherType, (gameMap.commanders.length * turns) - 1);
+    }
   }
 
   @Override

--- a/src/Engine/GameEvents/MapChangeEvent.java
+++ b/src/Engine/GameEvents/MapChangeEvent.java
@@ -1,5 +1,7 @@
 package Engine.GameEvents;
 
+import java.util.ArrayList;
+
 import Engine.XYCoord;
 import Terrain.Environment;
 import Terrain.Location;
@@ -8,32 +10,23 @@ import UI.MapView;
 import UI.Art.Animation.GameAnimation;
 
 /**
- * This event changes the environment (terrain type, weather, or both) of a map tile.
+ * This event changes the TerrainType and/or Weather of one or more map tiles.
  */
 public class MapChangeEvent implements GameEvent
 {
-  private XYCoord where;
-  private Environment myEnvironment;
-  private int turns;
+  private ArrayList<EnvironmentAssignment> changes;
 
-  /** For when you just want to redraw the map */
-  public MapChangeEvent()
+  /** Simple constructor for changing a single tile */
+  public MapChangeEvent(XYCoord location, Environment envi)
   {
-    this(null, null, 0);
+    changes = new ArrayList<EnvironmentAssignment>();
+    changes.add(new EnvironmentAssignment(location, envi));
   }
 
-  /** For changing terrain type */
-  public MapChangeEvent(XYCoord location, Environment newTile)
+  /** Allows changing a set of tiles all at once. */
+  public MapChangeEvent(ArrayList<EnvironmentAssignment> envChanges)
   {
-    this(location, newTile, 0);
-  }
-
-  /** For changing weather */
-  public MapChangeEvent(XYCoord location, Environment newTile, int duration)
-  {
-    where = location;
-    myEnvironment = newTile;
-    turns = duration;
+    changes = envChanges;
   }
 
   @Override
@@ -45,30 +38,57 @@ public class MapChangeEvent implements GameEvent
   @Override
   public void sendToListener(GameEventListener listener)
   {
-    listener.receiveMapChangeEvent(this);
+    listener.receiveTerrainChangeEvent(changes);
   }
 
   @Override
   public void performEvent(MapMaster gameMap)
   {
-    Location loc = gameMap.getLocation(where);
-    if( null != loc )
+    for( EnvironmentAssignment ea : changes )
     {
-      loc.setEnvironment(myEnvironment);
-      if (turns > 0)
-        loc.setForecast(myEnvironment.weatherType, (gameMap.commanders.length * turns) - 1);
+      Location loc = gameMap.getLocation(ea.where);
+      if( null != loc )
+      {
+        loc.setEnvironment(ea.environment);
+        if( ea.duration > 0 )
+          loc.setForecast(ea.environment.weatherType, (gameMap.commanders.length * ea.duration) - 1);
+      }
     }
   }
 
   @Override
   public XYCoord getStartPoint()
   {
-    return where;
+    return changes.get(0).where;
   }
 
   @Override
   public XYCoord getEndPoint()
   {
-    return where;
+    return changes.get(0).where;
+  }
+
+  public static class EnvironmentAssignment
+  {
+    public final XYCoord where;
+    public final Environment environment;
+    public final int duration;
+
+    public EnvironmentAssignment(XYCoord xyc, Environment envi)
+    {
+      this(xyc, envi, 0);
+    }
+
+    /**
+     * @param xyc The location whose Environment is changing.
+     * @param envi The new TerrainType and weather to apply.
+     * @param forecastDuration The number of rounds for the weather should persist.
+     */
+    public EnvironmentAssignment(XYCoord xyc, Environment envi, int forecastDuration)
+    {
+      where = xyc;
+      environment = envi;
+      duration = forecastDuration;
+    }
   }
 }

--- a/src/Engine/GameInstance.java
+++ b/src/Engine/GameInstance.java
@@ -1,18 +1,17 @@
 package Engine;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 
 import CommandingOfficers.Commander;
 import Engine.GameEvents.GameEventListener;
 import Engine.GameEvents.GameEventQueue;
 import Engine.GameEvents.MapChangeEvent;
+import Terrain.Environment;
+import Terrain.Environment.Weathers;
 import Terrain.Location;
 import Terrain.MapMaster;
 import Terrain.MapWindow;
-import Terrain.Environment;
-import Terrain.GameMap;
-import Terrain.Location;
-import Terrain.Environment.Weathers;
 
 public class GameInstance
 {
@@ -145,25 +144,34 @@ public class GameInstance
     } while (activeCO.isDefeated);
 
     // Set weather conditions based on forecast
-    events.push(new MapChangeEvent());
+    ArrayList<MapChangeEvent.EnvironmentAssignment> weatherChanges = new ArrayList<MapChangeEvent.EnvironmentAssignment>();
     for( int i = 0; i < gameMap.mapWidth; i++ )
     {
       for( int j = 0; j < gameMap.mapHeight; j++ )
       {
         Location loc = gameMap.getLocation(i, j);
-        for( int turns = 0; turns < coTurns; turns++ )
+        if( loc.forecast.isEmpty() )
         {
-          if( loc.forecast.isEmpty() )
+          if( loc.getEnvironment().weatherType != Weathers.CLEAR )
           {
-            loc.setEnvironment(Environment.getTile(loc.getEnvironment().terrainType, Weathers.CLEAR));
-            break;
-          }
-          else
-          {
-            loc.setEnvironment(Environment.getTile(loc.getEnvironment().terrainType, loc.forecast.poll()));
+            weatherChanges.add(new MapChangeEvent.EnvironmentAssignment(loc.getCoordinates(), Environment.getTile(loc.getEnvironment().terrainType, Weathers.CLEAR)));
           }
         }
+        else
+        {
+          Weathers weather = loc.getEnvironment().weatherType;
+          for( int turns = 0; turns < coTurns; turns++ )
+          {
+            weather = loc.forecast.poll();
+          }
+          if( null == weather ) weather = Weathers.CLEAR;
+          weatherChanges.add(new MapChangeEvent.EnvironmentAssignment(loc.getCoordinates(), Environment.getTile(loc.getEnvironment().terrainType, weather)));
+        }
       }
+    }
+    if( !weatherChanges.isEmpty() )
+    {
+      events.add(new MapChangeEvent(weatherChanges));
     }
 
     // Set the cursor to the new CO's last known cursor position.

--- a/src/Engine/GameInstance.java
+++ b/src/Engine/GameInstance.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import CommandingOfficers.Commander;
 import Engine.GameEvents.GameEventListener;
 import Engine.GameEvents.GameEventQueue;
+import Engine.GameEvents.MapChangeEvent;
 import Terrain.Location;
 import Terrain.MapMaster;
 import Terrain.MapWindow;
@@ -26,15 +27,15 @@ public class GameInstance
 
   private boolean isFogEnabled;
 
-  public GameInstance(MapMaster map, Commander[] cos)
+  public GameInstance(MapMaster map)
   {
-    if( cos.length < 2 )
+    if( map.commanders.length < 2 )
     {
       System.out.println("WARNING! Creating a game with fewer than two commanders.");
     }
 
     gameMap = map;
-    commanders = cos;
+    commanders = map.commanders;
     activeCoNum = -1; // No commander is active yet.
 
     // Set the initial cursor locations for each player.
@@ -144,6 +145,7 @@ public class GameInstance
     } while (activeCO.isDefeated);
 
     // Set weather conditions based on forecast
+    events.push(new MapChangeEvent());
     for( int i = 0; i < gameMap.mapWidth; i++ )
     {
       for( int j = 0; j < gameMap.mapHeight; j++ )
@@ -167,8 +169,10 @@ public class GameInstance
     // Set the cursor to the new CO's last known cursor position.
     setCursorLocation(playerCursors.get(activeCoNum).xCoord, playerCursors.get(activeCoNum).yCoord);
     
+    events.addAll(activeCO.initTurn(gameMap));
+    
     // Initialize the next turn, recording any events that will occur.
-    return activeCO.initTurn(gameMap);
+    return events;
   }
 
   /**

--- a/src/Terrain/Environment.java
+++ b/src/Terrain/Environment.java
@@ -13,7 +13,7 @@ public class Environment
   
   public enum Weathers
   {
-    CLEAR, RAIN, SNOW, SANDSTORM
+    CLEAR, SNOW, RAIN, SANDSTORM
   };
 
   public final TerrainType terrainType;

--- a/src/Terrain/Location.java
+++ b/src/Terrain/Location.java
@@ -1,7 +1,10 @@
 package Terrain;
 
+import java.util.ArrayDeque;
+
 import CommandingOfficers.Commander;
 import Engine.XYCoord;
+import Terrain.Environment.Weathers;
 import Units.Unit;
 
 public class Location
@@ -11,6 +14,7 @@ public class Location
   private Unit resident = null;
   private final XYCoord coords;
   private boolean highlightSet = false;
+  public ArrayDeque<Weathers> forecast = new ArrayDeque<>();
 
   public Environment getEnvironment()
   {
@@ -87,5 +91,18 @@ public class Location
     owner = null;
     resident = null;
     coords = coordinates;
+  }
+  
+  public void setForecast(Weathers w, int duration)
+  {
+    setEnvironment(Environment.getTile(getEnvironment().terrainType, w));
+    for( int turns = 0; turns < duration; turns++ )
+    {
+      forecast.poll();
+    }
+    for( int turns = 0; turns < duration; turns++ )
+    {
+      forecast.push(w);
+    }
   }
 }

--- a/src/Terrain/Location.java
+++ b/src/Terrain/Location.java
@@ -98,11 +98,11 @@ public class Location
     setEnvironment(Environment.getTile(getEnvironment().terrainType, w));
     for( int turns = 0; turns < duration; turns++ )
     {
-      forecast.poll();
+      forecast.pollFirst();
     }
     for( int turns = 0; turns < duration; turns++ )
     {
-      forecast.push(w);
+      forecast.addFirst(w);
     }
   }
 }

--- a/src/Terrain/MapMaster.java
+++ b/src/Terrain/MapMaster.java
@@ -121,7 +121,9 @@ public class MapMaster extends GameMap
   /** Returns the Location at the specified location, or null if that Location does not exist. */
   public Location getLocation(XYCoord location)
   {
-    return getLocation(location.xCoord, location.yCoord);
+    if (null != location)
+      return getLocation(location.xCoord, location.yCoord);
+    return null;
   }
 
   /** Returns the Location at the specified location, or null if that Location does not exist. */

--- a/src/Terrain/MapWindow.java
+++ b/src/Terrain/MapWindow.java
@@ -71,7 +71,7 @@ public class MapWindow extends GameMap
   /** Returns the Location at the specified location, or null if that Location does not exist. */
   public Location getLocation(XYCoord location)
   {
-    return getLocation(location.xCoord, location.yCoord);
+    return master.getLocation(location);
   }
 
   /** Returns the Location at the specified location, or null if that Location does not exist. */

--- a/src/Terrain/MapWindow.java
+++ b/src/Terrain/MapWindow.java
@@ -71,7 +71,9 @@ public class MapWindow extends GameMap
   /** Returns the Location at the specified location, or null if that Location does not exist. */
   public Location getLocation(XYCoord location)
   {
-    return master.getLocation(location);
+    if (null != location)
+      return getLocation(location.xCoord, location.yCoord);
+    return null;
   }
 
   /** Returns the Location at the specified location, or null if that Location does not exist. */

--- a/src/Test/TestCommanderAve.java
+++ b/src/Test/TestCommanderAve.java
@@ -4,6 +4,7 @@ import CommandingOfficers.Commander;
 import CommandingOfficers.CommanderAve;
 import CommandingOfficers.CommanderPatch;
 import Engine.GameAction;
+import Engine.GameInstance;
 import Engine.Utils;
 import Engine.XYCoord;
 import Engine.GameEvents.GameEvent;
@@ -19,9 +20,10 @@ import Units.UnitModel.UnitEnum;
 
 public class TestCommanderAve extends TestCase
 {
-  private static Commander Patch;
-  private static CommanderAve Ave;
-  private static MapMaster testMap;
+  private Commander Patch;
+  private CommanderAve Ave;
+  private MapMaster testMap;
+  private GameInstance game;
 
   private void setupTest()
   {
@@ -35,6 +37,7 @@ public class TestCommanderAve extends TestCase
     {
       co.myView = new MapWindow(testMap, co);
     }
+    game = new GameInstance(testMap);
   }
 
   @Override
@@ -48,6 +51,7 @@ public class TestCommanderAve extends TestCase
     testPassed &= validate(testCapture(), "  Capture test failed!");
     testPassed &= validate(testGlacio(), "  Glacio test failed!");
 
+    game.endGame();
     return testPassed;
   }
 
@@ -120,7 +124,7 @@ public class TestCommanderAve extends TestCase
     testMap.getLocation(snowCity).setOwner(null);
     for( int i = 1; i < maxIters; ++i )
     {
-      GameEventQueue turnEvents = Ave.initTurn(testMap);
+      GameEventQueue turnEvents = game.turn();
       for(GameEvent event: turnEvents) event.performEvent(testMap);
       Environment cityEnv = testMap.getEnvironment(snowCity); 
       if( cityEnv.weatherType != Weathers.SNOW )

--- a/src/UI/COSetupController.java
+++ b/src/UI/COSetupController.java
@@ -72,7 +72,7 @@ public class COSetupController implements IController
         MapMaster map = new MapMaster( cos, gameBuilder.mapInfo );
         if( map.initOK() )
         {
-          GameInstance newGame = new GameInstance(map, cos);
+          GameInstance newGame = new GameInstance(map);
 
           MapView mv = Driver.getInstance().gameGraphics.createMapView(newGame);
           MapController mapController = new MapController(newGame, mv);


### PR DESCRIPTION
This is just the basic queuing logic I added on the AWBW branch.

I still like the idea of adding a weather "strength" value, and I'm not sure my implementation of how the event should work is as good as it could be.

There's a *very* noticeable delay on Ave's turns after the first bit, since Ave has to push events for every snowed tile, to keep them updated.

Perhaps the proper solution is for Ave to `setForecast()` herself, and only push events for the changing tiles... but then she'd have to redraw the map anyway.
Maybe the only weather change event should be the one pushed by GameInstance.

IDK, thoughts?