### PR TITLE
Moved PlayerSetupColorFactionArtist sprite preloading onto a separate thread

### DIFF
--- a/src/UI/Art/SpriteArtist/PlayerSetupArtist.java
+++ b/src/UI/Art/SpriteArtist/PlayerSetupArtist.java
@@ -57,8 +57,6 @@ public class PlayerSetupArtist
         PlayerSetupAiArtist.draw(g, subMenu, control.getPlayerInfo(control.getHighlightedPlayer()).getCurrentColor());
       }
     }
-    // Start preloading infantry sprites in the background so the ColorFaction screen doesn't freeze on first entry.
-    PlayerSetupColorFactionArtist.startSpritePreloader(control.getIconicUnit());
   }
 
   private static void drawPlayerSetup(Graphics g, MapInfo mapInfo, boolean snapCursor)

--- a/src/UI/Art/SpriteArtist/PlayerSetupArtist.java
+++ b/src/UI/Art/SpriteArtist/PlayerSetupArtist.java
@@ -58,7 +58,7 @@ public class PlayerSetupArtist
       }
     }
     // Start preloading infantry sprites in the background so the ColorFaction screen doesn't freeze on first entry.
-    PlayerSetupColorFactionArtist.preloadOneInfantrySprite(control.getIconicUnit());
+    PlayerSetupColorFactionArtist.startSpritePreloader(control.getIconicUnit());
   }
 
   private static void drawPlayerSetup(Graphics g, MapInfo mapInfo, boolean snapCursor)

--- a/src/UI/Art/SpriteArtist/PlayerSetupColorFactionArtist.java
+++ b/src/UI/Art/SpriteArtist/PlayerSetupColorFactionArtist.java
@@ -25,6 +25,14 @@ public class PlayerSetupColorFactionArtist
   private static SlidingValue gridY = new SlidingValue(0);
   private static SpriteCursor spriteCursor = new SpriteCursor(0, 0, SpriteLibrary.baseSpriteSize, SpriteLibrary.baseSpriteSize, UIUtils.getCOColors()[0]);
 
+  private static boolean donePreloading = false;
+  private static InfantrySpritePreloader isp;
+  public static void startSpritePreloader(String name)
+  {
+    if( !donePreloading && (null == isp) )
+    isp = new InfantrySpritePreloader(name);
+  }
+
   public static void draw(Graphics g, IController controller)
   {
     PlayerSetupColorFactionController control = (PlayerSetupColorFactionController)controller;
@@ -84,6 +92,12 @@ public class PlayerSetupColorFactionArtist
     BufferedImage image = SpriteLibrary.createTransparentSprite(myWidth, myHeight);
     Graphics myG = image.getGraphics();
 
+    if( !donePreloading )
+    {
+      isp.join();
+      isp = null;
+    }
+
     for( int c = 0; c < UIUtils.getCOColors().length; ++c)
       for(int f = 0; f < UIUtils.getFactions().length; ++f)
       {
@@ -127,25 +141,47 @@ public class PlayerSetupColorFactionArtist
     gridHeight = numFactions*unitSizePx + unitBuffer*(numFactions-1);
   }
 
-  private static int nextFac = 0;
-  private static int nextCol = 0;
-  private static boolean donePreloading = false;
-  /** This can be called repeatedly on the sly to get all infantry sprites
-   * in memory and make this option screen less sluggish on first entry. */
-  public static boolean preloadOneInfantrySprite(String unitName)
+  public static class InfantrySpritePreloader implements Runnable
   {
-    if( !donePreloading )
+    private Thread myThread;
+    private String myUnitName;
+    private int nextFac = 0;
+    private int nextCol = 0;
+
+    public InfantrySpritePreloader(String unitName)
     {
-      SpriteLibrary.getMapUnitSpriteSet(unitName, UIUtils.getFactions()[nextFac], UIUtils.getCOColors()[nextCol]);
-      nextFac++;
-      if( nextFac >= UIUtils.getFactions().length )
+      myThread = new Thread(this);
+      myThread.start();
+      myUnitName = unitName;
+    }
+
+    @Override
+    public void run()
+    {
+      while( !donePreloading )
       {
-        nextFac = 0;
-        nextCol++;
-        if( nextCol >= UIUtils.getCOColors().length )
-          donePreloading = true;
+        SpriteLibrary.getMapUnitSpriteSet(myUnitName, UIUtils.getFactions()[nextFac], UIUtils.getCOColors()[nextCol]);
+        nextFac++;
+        if( nextFac >= UIUtils.getFactions().length )
+        {
+          nextFac = 0;
+          nextCol++;
+          if( nextCol >= UIUtils.getCOColors().length )
+            donePreloading = true;
+        }
       }
     }
-    return donePreloading;
+
+    public void join()
+    {
+      try
+      {
+        myThread.join();
+      }
+      catch(InterruptedException ie)
+      {
+        System.out.println("[InfantrySpritePreloader] Exception! Details:\n  " + ie.toString());
+      }
+    }
   }
 }

--- a/src/UI/Art/SpriteArtist/PlayerSetupColorFactionArtist.java
+++ b/src/UI/Art/SpriteArtist/PlayerSetupColorFactionArtist.java
@@ -92,7 +92,7 @@ public class PlayerSetupColorFactionArtist
     BufferedImage image = SpriteLibrary.createTransparentSprite(myWidth, myHeight);
     Graphics myG = image.getGraphics();
 
-    if( !donePreloading )
+    if( isp != null )
     {
       isp.join();
       isp = null;
@@ -145,8 +145,6 @@ public class PlayerSetupColorFactionArtist
   {
     private Thread myThread;
     private String myUnitName;
-    private int nextFac = 0;
-    private int nextCol = 0;
 
     public InfantrySpritePreloader(String unitName)
     {
@@ -158,18 +156,14 @@ public class PlayerSetupColorFactionArtist
     @Override
     public void run()
     {
-      while( !donePreloading )
+      for( int nextCol = 0; nextCol < UIUtils.getCOColors().length; ++nextCol )
       {
-        SpriteLibrary.getMapUnitSpriteSet(myUnitName, UIUtils.getFactions()[nextFac], UIUtils.getCOColors()[nextCol]);
-        nextFac++;
-        if( nextFac >= UIUtils.getFactions().length )
+        for( int nextFac = 0; nextFac < UIUtils.getFactions().length; ++nextFac )
         {
-          nextFac = 0;
-          nextCol++;
-          if( nextCol >= UIUtils.getCOColors().length )
-            donePreloading = true;
+          SpriteLibrary.getMapUnitSpriteSet(myUnitName, UIUtils.getFactions()[nextFac], UIUtils.getCOColors()[nextCol]);
         }
       }
+      donePreloading = true;
     }
 
     public void join()

--- a/src/UI/Art/SpriteArtist/SpriteEngine.java
+++ b/src/UI/Art/SpriteArtist/SpriteEngine.java
@@ -15,6 +15,7 @@ public class SpriteEngine implements GraphicsEngine
   @Override
   public IView getMainUIView(MainUIController control)
   {
+    PlayerSetupColorFactionArtist.startSpritePreloader("Infantry");
     return new MainUIView(control);
   }
 


### PR DESCRIPTION
This works, but:
We could just as easily initialize the sprite preloader thread statically, e.g.
`private static InfantrySpritePreloader isp = new InfantrySpritePreloader();`

This would cause the thread to kick off as soon as the owning class was loaded (when first referenced at run-time). We could also kick off the thread earlier - no reason to wait until we are almost about to access the screen to start preparing.

At any rate, this is still an improvement, since the preloading process would create jitter when we were running it on the UI thread.