### PR TITLE
Fixes #262 Join and MassDamage actions now correctly remove units.

### DIFF
--- a/src/Engine/GameEvents/MassDamageEvent.java
+++ b/src/Engine/GameEvents/MassDamageEvent.java
@@ -51,7 +51,14 @@ public class MassDamageEvent implements GameEvent
     {
       int deltaHP = 0;
       if( lethal )
+      {
         deltaHP = victim.damageHP(damage);
+        if( 0 == victim.getHP() )
+        {
+          gameMap.removeUnit(victim);
+          victim.CO.units.remove(victim);
+        }
+      }
       else
         deltaHP = victim.alterHP(-damage);
       int lostHP = -deltaHP;

--- a/src/Engine/GameEvents/MassDamageEvent.java
+++ b/src/Engine/GameEvents/MassDamageEvent.java
@@ -51,14 +51,7 @@ public class MassDamageEvent implements GameEvent
     {
       int deltaHP = 0;
       if( lethal )
-      {
         deltaHP = victim.damageHP(damage);
-        if( 0 == victim.getHP() )
-        {
-          gameMap.removeUnit(victim);
-          victim.CO.units.remove(victim);
-        }
-      }
       else
         deltaHP = victim.alterHP(-damage);
       int lostHP = -deltaHP;

--- a/src/Engine/UnitActionLifecycles/JoinLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/JoinLifecycle.java
@@ -183,6 +183,7 @@ public abstract class JoinLifecycle
 
         // Remove the donor unit.
         gameMap.removeUnit(unitDonor);
+        unitDonor.CO.units.remove(unitDonor);
 
         // End the turn of the recipient.
         unitRecipient.isTurnOver = true;


### PR DESCRIPTION
Turns out `JOIN`ing units would leave both in the CO's unit list. Then SEEK would still try to find it.