### PR TITLE
Fixes #324 FREE_TILE_SELECT override now only applies to ATTACK actions.

### DIFF
--- a/src/Engine/MapController.java
+++ b/src/Engine/MapController.java
@@ -255,7 +255,8 @@ public class MapController implements IController, GameInputHandler.StateChanged
 
         boolean useFreeSelect = false;
         // Switch to free-tile select in target-rich environments
-        if( !useFreeSelect && targetLocations.size() > 3 )
+        if( !useFreeSelect && targetLocations.size() > 3
+            && (myGameInputHandler.myStateData.actionSet.getGameActions().get(0).getType() == UnitActionFactory.ATTACK))
         {
           int maxDist = 0;
           for( XYCoord a : targetLocations )

--- a/src/Engine/MapController.java
+++ b/src/Engine/MapController.java
@@ -253,18 +253,10 @@ public class MapController implements IController, GameInputHandler.StateChanged
           System.out.println("WARNING! Attempting to choose a target for a non-targetable action.");
         }
 
-        boolean useFreeSelect = false;
         // Switch to free-tile select in target-rich environments
-        if( !useFreeSelect && targetLocations.size() > 3
-            && (myGameInputHandler.myStateData.actionSet.getGameActions().get(0).getType() == UnitActionFactory.ATTACK))
-        {
-          int maxDist = 0;
-          for( XYCoord a : targetLocations )
-            for( XYCoord b : targetLocations )
-              maxDist = Math.max(maxDist, a.getDistance(b));
-
-          useFreeSelect = maxDist < targetLocations.size();
-        }
+        boolean useFreeSelect = false;
+        if( targetLocations.size() > 6 )
+          useFreeSelect = true;
 
         if( useFreeSelect )
           handleFreeTileSelect(input);


### PR DESCRIPTION
Alright. So this works, but I'd still be more inclined to just take over the `FREE_TILE_SELECT` override altogether. It introduces unexpected behavior in edge cases (though admittedly it's unlikely to elicit input mistakes), but it also fails to engage at times when you would think it should, e.g. here:
![Screenshot from 2020-10-13 13-59-40](https://user-images.githubusercontent.com/16439262/95904285-e8463680-0d5c-11eb-88a7-75305a7af093.png)

It's not really a huge issue, I'm just not a fan of special cases, especially when the special handling affects non-special cases.