### PR TITLE
Tech debt

### DIFF
--- a/src/AI/AICombatUtils.java
+++ b/src/AI/AICombatUtils.java
@@ -21,7 +21,7 @@ import Engine.Combat.BattleSummary;
 import Engine.Combat.CombatEngine;
 import Engine.Combat.StrikeParams;
 import Terrain.GameMap;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.TerrainType;
 import Units.Unit;
 import Units.UnitModel;
@@ -43,7 +43,7 @@ public class AICombatUtils
                                          BiFunction<TerrainType, StrikeParams, Double> demolishScorer)
   {
     double score = 0;
-    Location targetLoc = map.getLocation(action.getTargetLocation());
+    MapLocation targetLoc = map.getLocation(action.getTargetLocation());
     Unit targetUnit = targetLoc.getResident();
     if( null != targetUnit )
     {
@@ -202,7 +202,7 @@ public class AICombatUtils
         continue;
       }
 
-      Location loc = gameMap.getLocation(xyc);
+      MapLocation loc = gameMap.getLocation(xyc);
       Unit resident = loc.getResident();
       if( null != resident && (resident.CO != co || resident.isTurnOver) )
       {

--- a/src/AI/AICombatUtils.java
+++ b/src/AI/AICombatUtils.java
@@ -14,7 +14,7 @@ import java.util.function.Function;
 
 import CommandingOfficers.Commander;
 import Engine.GameAction;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.Utils;
 import Engine.XYCoord;
 import Engine.Combat.BattleSummary;
@@ -309,7 +309,7 @@ public class AICombatUtils
           continue; // Consider each unit only once
 
         // Figure out how to get here.
-        Path movePath = Utils.findShortestPath(unit, xyc, gameMap);
+        GamePath movePath = Utils.findShortestPath(unit, xyc, gameMap);
 
         if( movePath.getPathLength() > 0 )
         {

--- a/src/AI/AIUtils.java
+++ b/src/AI/AIUtils.java
@@ -11,7 +11,7 @@ import CommandingOfficers.Commander;
 import CommandingOfficers.CommanderAbility;
 import Engine.GameAction;
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.Utils;
 import Engine.XYCoord;
@@ -55,7 +55,7 @@ public class AIUtils
     for( XYCoord coord : destinations )
     {
       // Figure out how to get here.
-      Path movePath = Utils.findShortestPath(unit, coord, gameMap);
+      GamePath movePath = Utils.findShortestPath(unit, coord, gameMap);
 
       // Figure out what I can do here.
       ArrayList<GameActionSet> actionSets = unit.getPossibleActions(gameMap, movePath, includeOccupiedDestinations);
@@ -200,7 +200,7 @@ public class AIUtils
     GameAction move = null;
 
     // Find the full path that would get this unit to the destination, regardless of how long. 
-    Path path = Utils.findShortestPath(unit, destination, gameMap, true);
+    GamePath path = Utils.findShortestPath(unit, destination, gameMap, true);
     boolean includeOccupiedSpaces = false;
     ArrayList<XYCoord> validMoves = Utils.findPossibleDestinations(unit, gameMap, includeOccupiedSpaces); // Find the valid moves we can make.
 

--- a/src/AI/AIUtils.java
+++ b/src/AI/AIUtils.java
@@ -17,7 +17,7 @@ import Engine.Utils;
 import Engine.XYCoord;
 import Engine.UnitActionLifecycles.WaitLifecycle;
 import Terrain.GameMap;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Units.Unit;
 
 public class AIUtils
@@ -125,7 +125,7 @@ public class AIUtils
     {
       for( int y = 0; y < gameMap.mapHeight; ++y )
       {
-        Location loc = gameMap.getLocation(x, y);
+        MapLocation loc = gameMap.getLocation(x, y);
         if( loc.isCaptureable() && myCo.isEnemy(loc.getOwner()) )
         {
           props.add(new XYCoord(x, y));
@@ -148,7 +148,7 @@ public class AIUtils
     {
       for( int y = 0; y < gameMap.mapHeight; ++y )
       {
-        Location loc = gameMap.getLocation(x, y);
+        MapLocation loc = gameMap.getLocation(x, y);
         if( loc.getResident() != null && myCo.isEnemy(loc.getResident().CO) )
         {
           unitLocs.add(new XYCoord(x, y));
@@ -227,7 +227,7 @@ public class AIUtils
     ArrayList<XYCoord> stations = new ArrayList<XYCoord>();
     for( XYCoord xyc : unit.CO.ownedProperties ) // TODO: Revisit if we ever get a CO that repairs on non-owned or non-properties
     {
-      Location loc = unit.CO.myView.getLocation(xyc);
+      MapLocation loc = unit.CO.myView.getLocation(xyc);
       if( unit.model.canRepairOn(loc) )
       {
         stations.add(loc.getCoordinates());

--- a/src/AI/CommanderProductionInfo.java
+++ b/src/AI/CommanderProductionInfo.java
@@ -9,7 +9,7 @@ import java.util.Set;
 import CommandingOfficers.Commander;
 import Engine.XYCoord;
 import Terrain.GameMap;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.TerrainType;
 import Units.Unit;
 import Units.UnitModel;
@@ -25,7 +25,7 @@ public class CommanderProductionInfo
 {
   public Commander myCo;
   public Set<UnitModel> availableUnitModels;
-  public Set<Location> availableProperties;
+  public Set<MapLocation> availableProperties;
   public Map<Terrain.TerrainType, Integer> propertyCounts;
   public Map<UnitModel, Set<TerrainType>> modelToTerrainMap;
 
@@ -38,13 +38,13 @@ public class CommanderProductionInfo
     // Figure out what unit types we can purchase with our available properties.
     myCo = co;
     availableUnitModels = new HashSet<UnitModel>();
-    availableProperties = new HashSet<Location>();
+    availableProperties = new HashSet<MapLocation>();
     propertyCounts = new HashMap<Terrain.TerrainType, Integer>();
     modelToTerrainMap = new HashMap<UnitModel, Set<TerrainType>>();
 
     for( XYCoord xyc : co.ownedProperties )
     {
-      Location loc = co.myView.getLocation(xyc);
+      MapLocation loc = co.myView.getLocation(xyc);
       Unit blocker = loc.getResident();
       if( null == blocker
           || (includeFriendlyOccupied && co == blocker.CO && !blocker.isTurnOver) )
@@ -76,11 +76,11 @@ public class CommanderProductionInfo
   /**
    * Return a location that can build the given unitModel, or null if none remains.
    */
-  public Location getLocationToBuild(UnitModel model)
+  public MapLocation getLocationToBuild(UnitModel model)
   {
     Set<TerrainType> desiredTerrains = modelToTerrainMap.get(model);
-    Location location = null;
-    for( Location loc : availableProperties )
+    MapLocation location = null;
+    for( MapLocation loc : availableProperties )
     {
       if( desiredTerrains.contains(loc.getEnvironment().terrainType) )
       {
@@ -94,7 +94,7 @@ public class CommanderProductionInfo
   /**
    * Remove the given location from further consideration, even if it is still available.
    */
-  public void removeBuildLocation(Location loc)
+  public void removeBuildLocation(MapLocation loc)
   {
     availableProperties.remove(loc);
     TerrainType terrain = loc.getEnvironment().terrainType;

--- a/src/AI/FightClub.java
+++ b/src/AI/FightClub.java
@@ -407,11 +407,8 @@ public class FightClub
         event.performEvent(game.gameMap);
 
         // Now that the event has been completed, let the world know.
-        GameEventListener.publishEvent(event, game);
+        eventQueue.addAll(GameEventListener.publishEvent(event, game));
       }
-
-      for( Commander co : game.commanders )
-        co.pollForEvents(eventQueue);
     }
   } // ~GameSet
 

--- a/src/AI/InfantrySpamAI.java
+++ b/src/AI/InfantrySpamAI.java
@@ -9,7 +9,7 @@ import CommandingOfficers.Commander;
 import CommandingOfficers.CommanderAbility;
 import Engine.GameAction;
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.Utils;
 import Engine.XYCoord;
@@ -165,7 +165,7 @@ public class InfantrySpamAI implements AIController
         log(String.format("  Seeking a property to send %s after", unit.toStringWithLocation()));
         int index = 0;
         XYCoord goal = null;
-        Path path = null;
+        GamePath path = null;
         boolean validTarget = false;
 
         // Loop until we find a valid property to go capture or run out of options.

--- a/src/AI/InfantrySpamAI.java
+++ b/src/AI/InfantrySpamAI.java
@@ -15,7 +15,7 @@ import Engine.Utils;
 import Engine.XYCoord;
 import Engine.UnitActionLifecycles.WaitLifecycle;
 import Terrain.GameMap;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.TerrainType;
 import Units.Unit;
 import Units.UnitModel;
@@ -213,7 +213,7 @@ public class InfantrySpamAI implements AIController
       {
         for( int j = 0; j < gameMap.mapHeight; j++)
         {
-          Location loc = gameMap.getLocation(i, j);
+          MapLocation loc = gameMap.getLocation(i, j);
           // If this terrain belongs to me, and I can build something on it, and I have the money, do so.
           if( loc.getEnvironment().terrainType == TerrainType.FACTORY && loc.getOwner() == myCo && loc.getResident() == null )
           {

--- a/src/AI/Muriel.java
+++ b/src/AI/Muriel.java
@@ -23,7 +23,7 @@ import Engine.Combat.CombatEngine;
 import Engine.UnitActionLifecycles.CaptureLifecycle;
 import Engine.UnitActionLifecycles.WaitLifecycle;
 import Terrain.GameMap;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.TerrainType;
 import Units.Unit;
 import Units.UnitModel;
@@ -351,7 +351,7 @@ public class Muriel implements AIController
 
     //////////////////////////////////////////////////////////////////
     // If we are currently healing, stick around, unless that would stem the tide of reinforcements.
-    Location loc = gameMap.getLocation(unit.x, unit.y);
+    MapLocation loc = gameMap.getLocation(unit.x, unit.y);
     if( (unit.getHP() <= 8) && unit.model.canRepairOn(loc) && (loc.getEnvironment().terrainType != TerrainType.FACTORY) && (loc.getOwner() == unit.CO) )
     {
       log(String.format("%s is damaged and on a repair tile. Will continue to repair for now.", unit.toStringWithLocation()));
@@ -408,7 +408,7 @@ public class Muriel implements AIController
       Utils.sortLocationsByDistance(unitCoords, stations);
       for( XYCoord coord : stations )
       {
-        Location station = gameMap.getLocation(coord);
+        MapLocation station = gameMap.getLocation(coord);
         // Go to the nearest unoccupied friendly space, but don't gum up the production lines.
         if( station.getResident() == null && (station.getEnvironment().terrainType != TerrainType.FACTORY) )
         {
@@ -934,7 +934,7 @@ public class Muriel implements AIController
         {
           // Go place orders.
           log(String.format("    I can build a %s for a cost of %s", idealCounter, cost));
-          Location loc = CPI.getLocationToBuild(idealCounter);
+          MapLocation loc = CPI.getLocationToBuild(idealCounter);
           shoppingCart.add(new PurchaseOrder(loc, idealCounter));
           budget -= idealCounter.getCost();
           CPI.removeBuildLocation(loc);
@@ -958,7 +958,7 @@ public class Muriel implements AIController
     UnitModel infModel = myCo.getUnitModel(UnitModel.TROOP);
     while( (budget >= infModel.getCost()) && (CPI.availableUnitModels.contains(infModel)) )
     {
-      Location loc = CPI.getLocationToBuild(infModel);
+      MapLocation loc = CPI.getLocationToBuild(infModel);
       shoppingCart.add(new PurchaseOrder(loc, infModel));
       budget -= infModel.getCost();
       CPI.removeBuildLocation(loc);
@@ -1039,10 +1039,10 @@ public class Muriel implements AIController
 
   private static class PurchaseOrder implements Comparable<PurchaseOrder>
   {
-    Location location;
+    MapLocation location;
     UnitModel model;
 
-    public PurchaseOrder(Location loc, UnitModel um)
+    public PurchaseOrder(MapLocation loc, UnitModel um)
     {
       location = loc;
       model = um;

--- a/src/AI/SpenderAI.java
+++ b/src/AI/SpenderAI.java
@@ -17,7 +17,7 @@ import Engine.Utils;
 import Engine.XYCoord;
 import Engine.UnitActionLifecycles.WaitLifecycle;
 import Terrain.GameMap;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.TerrainType;
 import Units.Unit;
 import Units.UnitModel;
@@ -229,7 +229,7 @@ public class SpenderAI implements AIController
             {
               for( XYCoord coord : unownedProperties )
               {
-                Location loc = gameMap.getLocation(coord);
+                MapLocation loc = gameMap.getLocation(coord);
                 if( loc.getEnvironment().terrainType == TerrainType.HEADQUARTERS && loc.getOwner() != null ) // should we have an attribute for this?
                 {
                   validTargets.add(coord);
@@ -287,10 +287,10 @@ public class SpenderAI implements AIController
       // We will add all build commands at once, since they can't conflict.
       if( actions.isEmpty() && !stateChange )
       {
-        Map<Location, ArrayList<UnitModel>> shoppingLists = new HashMap<>();
+        Map<MapLocation, ArrayList<UnitModel>> shoppingLists = new HashMap<>();
         for( XYCoord xyc : myCo.ownedProperties )
         {
-          Location loc = gameMap.getLocation(xyc);
+          MapLocation loc = gameMap.getLocation(xyc);
           // I like combat units that are useful, so we skip ports for now
           if( loc.getEnvironment().terrainType != TerrainType.SEAPORT && loc.getResident() == null )
           {
@@ -303,9 +303,9 @@ public class SpenderAI implements AIController
           }
         }
         int budget = myCo.money;
-        Map<Location, UnitModel> purchases = new HashMap<>();
+        Map<MapLocation, UnitModel> purchases = new HashMap<>();
         // Now that we know where and what we can buy, let's make some initial selections.
-        for( Entry<Location, ArrayList<UnitModel>> locShopList : shoppingLists.entrySet() )
+        for( Entry<MapLocation, ArrayList<UnitModel>> locShopList : shoppingLists.entrySet() )
         {
           ArrayList<UnitModel> units = locShopList.getValue();
           for( UnitModel unit : units )
@@ -319,12 +319,12 @@ public class SpenderAI implements AIController
             }
           }
         }
-        Queue<Entry<Location, ArrayList<UnitModel>>> upgradables = new ArrayDeque<>();
+        Queue<Entry<MapLocation, ArrayList<UnitModel>>> upgradables = new ArrayDeque<>();
         upgradables.addAll(shoppingLists.entrySet());
         // I want the most expensive single unit I can get, but I also want to spend as much money as possible
         while (!upgradables.isEmpty())
         {
-          Entry<Location, ArrayList<UnitModel>> locShopList = upgradables.poll();
+          Entry<MapLocation, ArrayList<UnitModel>> locShopList = upgradables.poll();
           ArrayList<UnitModel> units = locShopList.getValue();
           UnitModel currentPurchase = purchases.get(locShopList.getKey());
           if( null != currentPurchase )
@@ -342,7 +342,7 @@ public class SpenderAI implements AIController
           }
         }
         // once we're satisfied with all our selections, put in the orders
-        for( Entry<Location, UnitModel> lineItem : purchases.entrySet() )
+        for( Entry<MapLocation, UnitModel> lineItem : purchases.entrySet() )
         {
           GameAction action = new GameAction.UnitProductionAction(myCo, lineItem.getValue(),
               lineItem.getKey().getCoordinates());

--- a/src/AI/SpenderAI.java
+++ b/src/AI/SpenderAI.java
@@ -11,7 +11,7 @@ import CommandingOfficers.Commander;
 import CommandingOfficers.CommanderAbility;
 import Engine.GameAction;
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.Utils;
 import Engine.XYCoord;
@@ -165,7 +165,7 @@ public class SpenderAI implements AIController
         for( XYCoord coord : destinations )
         {
           // Figure out how to get here.
-          Path movePath = Utils.findShortestPath(unit, coord, gameMap);
+          GamePath movePath = Utils.findShortestPath(unit, coord, gameMap);
 
           // Figure out what I can do here.
           ArrayList<GameActionSet> actionSets = unit.getPossibleActions(gameMap, movePath);
@@ -217,7 +217,7 @@ public class SpenderAI implements AIController
             log(String.format("  Seeking a property to send %s after", unit.toStringWithLocation()));
             int index = 0;
             XYCoord goal = null;
-            Path path = null;
+            GamePath path = null;
             boolean validTarget = false;
             ArrayList<XYCoord> validTargets = new ArrayList<>();
 
@@ -265,7 +265,7 @@ public class SpenderAI implements AIController
               // and build a GameAction to move to the closest one.
               Utils.sortLocationsByDistance(goal, destinations);
               XYCoord destination = destinations.get(0);
-              Path movePath = Utils.findShortestPath(unit, destination, gameMap);
+              GamePath movePath = Utils.findShortestPath(unit, destination, gameMap);
               if( movePath.getPathLength() > 1 ) // We only want to try to travel if we can actually go somewhere
               {
                 GameAction move = new WaitLifecycle.WaitAction(unit, movePath);

--- a/src/AI/WallyAI.java
+++ b/src/AI/WallyAI.java
@@ -174,7 +174,7 @@ public class WallyAI extends ModularAI
         return bestAttack;
 
       // Figure out how to get here.
-      Path movePath = Utils.findShortestPath(unit, coord, gameMap);
+      GamePath movePath = Utils.findShortestPath(unit, coord, gameMap);
 
       // Figure out what I can do here.
       ArrayList<GameActionSet> actionSets = unit.getPossibleActions(gameMap, movePath);
@@ -411,7 +411,7 @@ public class WallyAI extends ModularAI
       for( XYCoord moveCoord : destinations )
       {
         // Figure out how to get here.
-        Path movePath = Utils.findShortestPath(unit, moveCoord, gameMap);
+        GamePath movePath = Utils.findShortestPath(unit, moveCoord, gameMap);
 
         // Figure out what I can do here.
         ArrayList<GameActionSet> actionSets = unit.getPossibleActions(gameMap, movePath, includeOccupiedSpaces);
@@ -727,7 +727,7 @@ public class WallyAI extends ModularAI
     // TODO: Jump in a transport, if available, or join?
 
     XYCoord goal = null;
-    Path path = null;
+    GamePath path = null;
     ArrayList<XYCoord> validTargets = findTravelDestinations(gameMap, allThreats, threatMap, unit, avoidProduction);
     if( mustMove ) // If we *must* travel, make sure we do actually move.
     {
@@ -779,7 +779,7 @@ public class WallyAI extends ModularAI
       }
       log(String.format("    Yes"));
 
-      Path movePath = Utils.findShortestPath(unit, xyc, gameMap);
+      GamePath movePath = Utils.findShortestPath(unit, xyc, gameMap);
       ArrayList<GameActionSet> actionSets = unit.getPossibleActions(gameMap, movePath, ignoreResident);
       if( actionSets.size() > 0 )
       {

--- a/src/AI/WallyAI.java
+++ b/src/AI/WallyAI.java
@@ -186,7 +186,7 @@ public class WallyAI extends ModularAI
         {
           for( GameAction action : actionSet.getGameActions() )
           {
-            Location loc = gameMap.getLocation(action.getTargetLocation());
+            MapLocation loc = gameMap.getLocation(action.getTargetLocation());
             Unit target = loc.getResident();
             if( null == target ) continue; // Ignore terrain
             double damage = valueUnit(target, loc, false) * Math.min(target.getHP(), CombatEngine.simulateBattleResults(unit, target, gameMap, unit.x, unit.y).defenderHPLoss);
@@ -397,7 +397,7 @@ public class WallyAI extends ModularAI
                                               boolean canEvict )
     {
       XYCoord position = new XYCoord(unit.x, unit.y);
-      Location unitLoc = gameMap.getLocation(position);
+      MapLocation unitLoc = gameMap.getLocation(position);
 
       boolean includeOccupiedSpaces = true; // Since we know how to shift friendly units out of the way
       ArrayList<XYCoord> destinations = Utils.findPossibleDestinations(unit, gameMap, includeOccupiedSpaces);
@@ -427,7 +427,7 @@ public class WallyAI extends ModularAI
           {
             for( GameAction ga : actionSet.getGameActions() )
             {
-              Location targetLoc = gameMap.getLocation(ga.getTargetLocation());
+              MapLocation targetLoc = gameMap.getLocation(ga.getTargetLocation());
               Unit target = targetLoc.getResident();
               if( null == target )
                 continue;
@@ -640,7 +640,7 @@ public class WallyAI extends ModularAI
     {
       for( XYCoord coord : unownedProperties )
       {
-        Location loc = gameMap.getLocation(coord);
+        MapLocation loc = gameMap.getLocation(coord);
         if( myCo.unitProductionByTerrain.containsKey(loc.getEnvironment().terrainType)
             && myCo.isEnemy(loc.getOwner()) )
         {
@@ -833,7 +833,7 @@ public class WallyAI extends ModularAI
    */
   private boolean canWallHere(GameMap gameMap, Map<UnitModel, Map<XYCoord, Double>> threatMap, Unit unit, XYCoord xyc)
   {
-    Location destination = gameMap.getLocation(xyc);
+    MapLocation destination = gameMap.getLocation(xyc);
     // if we're safe, we're safe
     if( isSafe(gameMap, threatMap, unit, xyc) )
       return true;
@@ -843,7 +843,7 @@ public class WallyAI extends ModularAI
     ArrayList<XYCoord> adjacentCoords = Utils.findLocationsInRange(gameMap, xyc, 1);
     for( XYCoord coord : adjacentCoords )
     {
-      Location loc = gameMap.getLocation(coord);
+      MapLocation loc = gameMap.getLocation(coord);
       if( loc != null )
       {
         Unit resident = loc.getResident();
@@ -857,7 +857,7 @@ public class WallyAI extends ModularAI
     return false;
   }
 
-  private static int valueUnit(Unit unit, Location locale, boolean includeCurrentHealth)
+  private static int valueUnit(Unit unit, MapLocation locale, boolean includeCurrentHealth)
   {
     int value = unit.model.getCost();
 
@@ -917,7 +917,7 @@ public class WallyAI extends ModularAI
   {
     Set<TerrainType> desiredTerrains = CPI.modelToTerrainMap.get(model);
     ArrayList<XYCoord> candidates = new ArrayList<XYCoord>();
-    for( Location loc : CPI.availableProperties )
+    for( MapLocation loc : CPI.availableProperties )
     {
       if( desiredTerrains.contains(loc.getEnvironment().terrainType) )
       {

--- a/src/CommandingOfficers/Ave.java
+++ b/src/CommandingOfficers/Ave.java
@@ -24,7 +24,7 @@ import Engine.GameEvents.MassDamageEvent;
 import Terrain.Environment;
 import Terrain.Environment.Weathers;
 import Terrain.GameMap;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.MapMaster;
 import Terrain.TerrainType;
 import Units.Unit;
@@ -772,7 +772,7 @@ public class Ave extends Commander
       Ave = cmdr;
     }
     @Override
-    public GameEventQueue receiveCaptureEvent(Unit unit, Location location)
+    public GameEventQueue receiveCaptureEvent(Unit unit, MapLocation location)
     {
       if( unit.CO == Ave && (location.getOwner() == Ave) )
       {

--- a/src/CommandingOfficers/Ave.java
+++ b/src/CommandingOfficers/Ave.java
@@ -763,7 +763,7 @@ public class Ave extends Commander
     }
   }
 
-  private static class CitySnowifier extends GameEventListener
+  private static class CitySnowifier implements GameEventListener
   {
     private static final long serialVersionUID = 1L;
     Ave Ave;
@@ -772,14 +772,16 @@ public class Ave extends Commander
       Ave = cmdr;
     }
     @Override
-    public void receiveCaptureEvent(Unit unit, Location location)
+    public GameEventQueue receiveCaptureEvent(Unit unit, Location location)
     {
       if( unit.CO == Ave && (location.getOwner() == Ave) )
       {
+        // TODO?
         // Just mark the tile as "snowy" until the next turnInit(), since we can't do a MapChangeEvent from here.
         XYCoord where = location.getCoordinates();
         Ave.snowMap[where.xCoord][where.yCoord] += SNOW_THRESHOLD;
       }
+      return null;
     }
   }
 }

--- a/src/CommandingOfficers/Ave.java
+++ b/src/CommandingOfficers/Ave.java
@@ -774,14 +774,17 @@ public class Ave extends Commander
     @Override
     public GameEventQueue receiveCaptureEvent(Unit unit, MapLocation location)
     {
+      GameEventQueue returnEvents = new GameEventQueue();
+
       if( unit.CO == Ave && (location.getOwner() == Ave) )
       {
-        // TODO?
-        // Just mark the tile as "snowy" until the next turnInit(), since we can't do a MapChangeEvent from here.
         XYCoord where = location.getCoordinates();
         Ave.snowMap[where.xCoord][where.yCoord] += SNOW_THRESHOLD;
+        returnEvents.add(
+            new MapChangeEvent( where, Environment.getTile(location.getEnvironment().terrainType, Weathers.SNOW) )
+            );
       }
-      return null;
+      return returnEvents;
     }
   }
 }

--- a/src/CommandingOfficers/Bear_Bull.java
+++ b/src/CommandingOfficers/Bear_Bull.java
@@ -11,7 +11,7 @@ import Engine.GameEvents.GameEventQueue;
 import Engine.GameEvents.MassDamageEvent;
 import Engine.GameEvents.ModifyFundsEvent;
 import Terrain.GameMap;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.MapMaster;
 import Units.Unit;
 import Units.UnitModel;
@@ -197,7 +197,7 @@ public class Bear_Bull extends Commander
       HashSet<Unit> victims = new HashSet<Unit>(); // Find all of our unlucky participants
       for( XYCoord xyc : myCommander.ownedProperties )
       {
-        Location loc = gameMap.getLocation(xyc);
+        MapLocation loc = gameMap.getLocation(xyc);
         if( loc.getOwner() == myCommander )
         {
           Unit victim = loc.getResident();

--- a/src/CommandingOfficers/Cinder.java
+++ b/src/CommandingOfficers/Cinder.java
@@ -11,7 +11,7 @@ import Engine.XYCoord;
 import Engine.Combat.BattleSummary;
 import Engine.GameEvents.GameEventListener;
 import Engine.GameEvents.GameEventQueue;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.MapMaster;
 import Units.Unit;
 import Units.UnitModel;
@@ -90,7 +90,7 @@ public class Cinder extends Commander
 
   @Override
   /** Get the list of units this commander can build from the given property type. */
-  public ArrayList<UnitModel> getShoppingList(Location buyLocation)
+  public ArrayList<UnitModel> getShoppingList(MapLocation buyLocation)
   {
     setPrices(buildCounts.get(buyLocation.getCoordinates()));
     return super.getShoppingList(buyLocation);
@@ -128,7 +128,7 @@ public class Cinder extends Commander
       for( int x = 0; x < map.mapWidth; ++x )
         for( int y = 0; y < map.mapHeight; ++y )
         {
-          Location loc = map.getLocation(x, y);
+          MapLocation loc = map.getLocation(x, y);
           if( loc.isCaptureable() ) // if we can't capture it, we can't build from it
             buildCounts.put(loc.getCoordinates(), 0);
         }

--- a/src/CommandingOfficers/Commander.java
+++ b/src/CommandingOfficers/Commander.java
@@ -421,8 +421,7 @@ public class Commander implements GameEventListener, Serializable
       // Convert funds to ability power units
       power /= CHARGERATIO_FUNDS;
 
-      modifyAbilityPower(42);
-//      modifyAbilityPower(power);
+      modifyAbilityPower(power);
     }
     return null;
   }

--- a/src/CommandingOfficers/Commander.java
+++ b/src/CommandingOfficers/Commander.java
@@ -31,7 +31,7 @@ import Engine.UuidGenerator;
 import Terrain.GameMap;
 import Terrain.MapLocation;
 import Terrain.MapMaster;
-import Terrain.MapWindow;
+import Terrain.MapFog;
 import Terrain.TerrainType;
 import UI.GameOverlay;
 import UI.UIUtils.Faction;
@@ -45,7 +45,7 @@ public class Commander implements GameEventListener, Serializable
   
   public final CommanderInfo coInfo;
   public final GameScenario.GameRules gameRules;
-  public MapWindow myView;
+  public MapFog myView;
   public ArrayList<Unit> units;
   public ArrayList<UnitModel> unitModels = new ArrayList<UnitModel>();
   public Map<TerrainType, ArrayList<UnitModel>> unitProductionByTerrain;

--- a/src/CommandingOfficers/Commander.java
+++ b/src/CommandingOfficers/Commander.java
@@ -39,7 +39,7 @@ import Units.Unit;
 import Units.UnitModel;
 import Units.UnitModelScheme.GameReadyModels;
 
-public class Commander extends GameEventListener implements Serializable
+public class Commander implements GameEventListener, Serializable
 {
   private static final long serialVersionUID = 1L;
   
@@ -172,12 +172,6 @@ public class Commander extends GameEventListener implements Serializable
 
     return events;
   }
-
-  /**
-   * This is called after every GameAction, and between turns, and allows Commanders to inject
-   * events that don't arise via normal gameplay. Most Commanders should not need to override this.
-   */
-  public void pollForEvents(GameEventQueue eventsOut) {}
 
   /**
    * @return whether these COs would like to kill each other
@@ -380,16 +374,17 @@ public class Commander extends GameEventListener implements Serializable
    * Track unit deaths, so I know not to be threatened by them.
    */
   @Override
-  public void receiveUnitDieEvent(Unit victim, XYCoord grave, Integer hpBeforeDeath)
+  public GameEventQueue receiveUnitDieEvent(Unit victim, XYCoord grave, Integer hpBeforeDeath)
   {
     threatsToOverlay.remove(victim);
+    return null;
   }
 
   /**
    * Track battles that happen, and get ability power based on combat this CO is in.
    */
   @Override
-  public void receiveBattleEvent(final BattleSummary summary)
+  public GameEventQueue receiveBattleEvent(final BattleSummary summary)
   {
     // We only care who the units belong to, not who picked the fight. 
     Unit minion = null;
@@ -426,18 +421,20 @@ public class Commander extends GameEventListener implements Serializable
       // Convert funds to ability power units
       power /= CHARGERATIO_FUNDS;
 
-      modifyAbilityPower(power);
+      modifyAbilityPower(42);
+//      modifyAbilityPower(power);
     }
+    return null;
   }
 
   /**
    * Track mass damage done to my units, and get ability power based on it.
    */
   @Override
-  public void receiveMassDamageEvent(Commander attacker, Map<Unit, Integer> lostHP)
+  public GameEventQueue receiveMassDamageEvent(Commander attacker, Map<Unit, Integer> lostHP)
   {
     if( this == attacker )
-      return; // Punching yourself shouldn't make you angry
+      return null; // Punching yourself shouldn't make you angry
 
     for( Entry<Unit, Integer> damageEntry : lostHP.entrySet() )
     {
@@ -453,6 +450,7 @@ public class Commander extends GameEventListener implements Serializable
         modifyAbilityPower(power);
       }
     }
+    return null;
   }
 
   public void setAIController(AIController ai)

--- a/src/CommandingOfficers/Commander.java
+++ b/src/CommandingOfficers/Commander.java
@@ -31,7 +31,7 @@ import Engine.UuidGenerator;
 import Terrain.GameMap;
 import Terrain.MapLocation;
 import Terrain.MapMaster;
-import Terrain.MapFog;
+import Terrain.MapPerspective;
 import Terrain.TerrainType;
 import UI.GameOverlay;
 import UI.UIUtils.Faction;
@@ -45,7 +45,7 @@ public class Commander implements GameEventListener, Serializable
   
   public final CommanderInfo coInfo;
   public final GameScenario.GameRules gameRules;
-  public MapFog myView;
+  public MapPerspective myView;
   public ArrayList<Unit> units;
   public ArrayList<UnitModel> unitModels = new ArrayList<UnitModel>();
   public Map<TerrainType, ArrayList<UnitModel>> unitProductionByTerrain;

--- a/src/CommandingOfficers/Commander.java
+++ b/src/CommandingOfficers/Commander.java
@@ -29,7 +29,7 @@ import Engine.GameEvents.GameEventListener;
 import Engine.GameEvents.GameEventQueue;
 import Engine.UuidGenerator;
 import Terrain.GameMap;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.MapMaster;
 import Terrain.MapWindow;
 import Terrain.TerrainType;
@@ -259,7 +259,7 @@ public class Commander implements GameEventListener, Serializable
   }
 
   /** Get the list of units this commander can build from the given property type. */
-  public ArrayList<UnitModel> getShoppingList(Location buyLocation)
+  public ArrayList<UnitModel> getShoppingList(MapLocation buyLocation)
   {
     return (unitProductionByTerrain.get(buyLocation.getEnvironment().terrainType) != null) ? unitProductionByTerrain.get(buyLocation.getEnvironment().terrainType)
         : new ArrayList<UnitModel>();

--- a/src/CommandingOfficers/Meridian.java
+++ b/src/CommandingOfficers/Meridian.java
@@ -86,12 +86,13 @@ public class Meridian extends Commander
   }
 
   @Override // GameEventListener interface
-  public void receiveUnitTransformEvent(Unit unit, UnitModel oldType)
+  public GameEventQueue receiveUnitTransformEvent(Unit unit, UnitModel oldType)
   {
     if (this == unit.CO)
     {
       justTransformed.add(unit);
     }
+    return null;
   }
 
   /**

--- a/src/CommandingOfficers/Patch.java
+++ b/src/CommandingOfficers/Patch.java
@@ -6,6 +6,7 @@ import Engine.GameInstance;
 import Engine.GameScenario;
 import Engine.Combat.BattleSummary;
 import Engine.GameEvents.GameEventListener;
+import Engine.GameEvents.GameEventQueue;
 import Terrain.Location;
 import Terrain.MapMaster;
 import Units.Unit;
@@ -93,7 +94,7 @@ public class Patch extends Commander
    * LootAbility is a passive that grants its Commander a day's income immediately upon capturing a
    * property, so long as that property is one that generates income.
    */
-  private static class LootAbility extends GameEventListener
+  private static class LootAbility implements GameEventListener
   {
     private static final long serialVersionUID = 1L;
     private Patch myCommander = null;
@@ -104,13 +105,14 @@ public class Patch extends Commander
     }
 
     @Override
-    public void receiveCaptureEvent(Unit unit, Location location)
+    public GameEventQueue receiveCaptureEvent(Unit unit, Location location)
     {
       if( unit.CO == myCommander && location.getOwner() == myCommander && location.isProfitable() )
       {
         // We just successfully captured a property. Loot the place!
         myCommander.money += myCommander.gameRules.incomePerCity;
       }
+      return null;
     }
   }
 
@@ -120,7 +122,7 @@ public class Patch extends Commander
    * Commander. The amount of income is a fraction of value of the damage that was done, thus
    * damaging more expensive units will grant more income.
    */
-  private static class DamageDealtToIncomeConverter extends GameEventListener
+  private static class DamageDealtToIncomeConverter implements GameEventListener
   {
     private static final long serialVersionUID = 1L;
     private Patch myCommander = null;
@@ -131,7 +133,7 @@ public class Patch extends Commander
     }
 
     @Override
-    public void receiveBattleEvent(BattleSummary battleInfo)
+    public GameEventQueue receiveBattleEvent(BattleSummary battleInfo)
     {
       // Determine if we were part of this fight. If so, cash in on any damage done to the other guy.
       double hpLoss = 0;
@@ -150,6 +152,7 @@ public class Patch extends Commander
       // Do the necessary math, then round to the nearest int.
       int income = (int)(hpLoss * (unitCost/10.0) * myCommander.myIncomeRatio + 0.5);
       myCommander.money += income;
+      return null;
     }
   }
 

--- a/src/CommandingOfficers/Patch.java
+++ b/src/CommandingOfficers/Patch.java
@@ -7,7 +7,7 @@ import Engine.GameScenario;
 import Engine.Combat.BattleSummary;
 import Engine.GameEvents.GameEventListener;
 import Engine.GameEvents.GameEventQueue;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.MapMaster;
 import Units.Unit;
 
@@ -105,7 +105,7 @@ public class Patch extends Commander
     }
 
     @Override
-    public GameEventQueue receiveCaptureEvent(Unit unit, Location location)
+    public GameEventQueue receiveCaptureEvent(Unit unit, MapLocation location)
     {
       if( unit.CO == myCommander && location.getOwner() == myCommander && location.isProfitable() )
       {

--- a/src/CommandingOfficers/Tech.java
+++ b/src/CommandingOfficers/Tech.java
@@ -23,7 +23,7 @@ import Engine.GameEvents.CommanderDefeatEvent;
 import Engine.GameEvents.GameEventQueue;
 import Engine.GameEvents.CreateUnitEvent;
 import Terrain.GameMap;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.MapMaster;
 import Terrain.TerrainType;
 import Units.Unit;
@@ -484,7 +484,7 @@ public class Tech extends Commander
           invalidDropCoords.add(pdc);
 
         // No trespassing
-        Location xycl = gameMap.getLocation(pdc);
+        MapLocation xycl = gameMap.getLocation(pdc);
         if( xycl.isCaptureable() && (null != xycl.getOwner()) && xycl.getOwner().isEnemy(myCommander) )
           invalidDropCoords.add(pdc);
 

--- a/src/CommandingOfficers/Venge.java
+++ b/src/CommandingOfficers/Venge.java
@@ -100,10 +100,11 @@ public class Venge extends Commander
   }
 
   @Override
-  public void receiveUnitJoinEvent(JoinEvent join)
+  public GameEventQueue receiveUnitJoinEvent(JoinEvent join)
   {
     if (aggressors.contains(join.unitDonor))
       aggressors.add(join.unitRecipient);
+    return null;
   }
 
   @Override
@@ -148,7 +149,7 @@ public class Venge extends Commander
   }
 
   @Override
-  public void receiveBattleEvent(BattleSummary battleInfo)
+  public GameEventQueue receiveBattleEvent(BattleSummary battleInfo)
   {
     super.receiveBattleEvent(battleInfo);
     // Determine if we were attacked. If so, record this misdeed.
@@ -156,6 +157,7 @@ public class Venge extends Commander
     {
       aggressors.add(battleInfo.attacker);
     }
+    return null;
   }
 
   /**

--- a/src/Engine/Combat/CombatEngine.java
+++ b/src/Engine/Combat/CombatEngine.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import Engine.Path;
+import Engine.GamePath;
 import Engine.XYCoord;
 import Engine.Combat.StrikeParams.BattleParams;
 import Terrain.GameMap;
@@ -43,7 +43,7 @@ public class CombatEngine
     return simulateBattleResults(attacker, defender, map, moveCoord.xCoord, moveCoord.yCoord);
   }
 
-  public static StrikeParams calculateTerrainDamage( Unit attacker, Path path, Location target, GameMap map )
+  public static StrikeParams calculateTerrainDamage( Unit attacker, GamePath path, Location target, GameMap map )
   {
     int battleRange = path.getEndCoord().getDistance(target.getCoordinates());
     boolean attackerMoved = path.getPathLength() > 1;

--- a/src/Engine/Combat/CombatEngine.java
+++ b/src/Engine/Combat/CombatEngine.java
@@ -9,7 +9,7 @@ import Engine.GamePath;
 import Engine.XYCoord;
 import Engine.Combat.StrikeParams.BattleParams;
 import Terrain.GameMap;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.MapMaster;
 import Units.Unit;
 import Units.WeaponModel;
@@ -43,7 +43,7 @@ public class CombatEngine
     return simulateBattleResults(attacker, defender, map, moveCoord.xCoord, moveCoord.yCoord);
   }
 
-  public static StrikeParams calculateTerrainDamage( Unit attacker, GamePath path, Location target, GameMap map )
+  public static StrikeParams calculateTerrainDamage( Unit attacker, GamePath path, MapLocation target, GameMap map )
   {
     int battleRange = path.getEndCoord().getDistance(target.getCoordinates());
     boolean attackerMoved = path.getPathLength() > 1;

--- a/src/Engine/FloodFillFunctor.java
+++ b/src/Engine/FloodFillFunctor.java
@@ -11,12 +11,12 @@ import Units.MoveTypes.MoveType;
 public interface FloodFillFunctor
 {
   /**
-   * Determines whether the Location (x, y), can be traveled through.
+   * Determines whether the MapLocation (x, y), can be traveled through.
    * @param ignoreUnits If set, this function will ignore enemy-unit presence.
    */
   int getTransitionCost(GameMap map, XYCoord from, XYCoord to);
   /**
-   * Determines whether the Location (x, y), is a valid destination.
+   * Determines whether the MapLocation (x, y), is a valid destination.
    */
   boolean canEnd(GameMap map, XYCoord end);
 

--- a/src/Engine/GameAction.java
+++ b/src/Engine/GameAction.java
@@ -17,7 +17,7 @@ import Engine.GameEvents.UnitDieEvent;
 import Engine.GameEvents.TeleportEvent.AnimationStyle;
 import Engine.GameEvents.TeleportEvent.CollisionOutcome;
 import Terrain.GameMap;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.MapMaster;
 import Units.Unit;
 import Units.UnitModel;
@@ -77,7 +77,7 @@ public abstract class GameAction
       isValid &= (null != gameMap) && (null != who) && (null != what) && (null != where);
       if( isValid )
       {
-        Location site = gameMap.getLocation(where);
+        MapLocation site = gameMap.getLocation(where);
         isValid &= (null == site.getResident());
         isValid &= site.getOwner() == who;
         isValid &= who.getShoppingList(site).contains(what);

--- a/src/Engine/GameEvents/CommanderAbilityEvent.java
+++ b/src/Engine/GameEvents/CommanderAbilityEvent.java
@@ -24,9 +24,10 @@ public class CommanderAbilityEvent implements GameEvent
   }
 
   @Override
-  public void sendToListener(GameEventListener listener)
+  public GameEventQueue sendToListener(GameEventListener listener)
   {
     // TODO Auto-generated method stub
+    return null;
   }
 
   @Override

--- a/src/Engine/GameEvents/CommanderDefeatEvent.java
+++ b/src/Engine/GameEvents/CommanderDefeatEvent.java
@@ -31,9 +31,9 @@ public class CommanderDefeatEvent implements GameEvent
   }
 
   @Override
-  public void sendToListener(GameEventListener listener)
+  public GameEventQueue sendToListener(GameEventListener listener)
   {
-    listener.receiveCommanderDefeatEvent( this );
+    return listener.receiveCommanderDefeatEvent( this );
   }
 
   @Override

--- a/src/Engine/GameEvents/CommanderDefeatEvent.java
+++ b/src/Engine/GameEvents/CommanderDefeatEvent.java
@@ -3,7 +3,7 @@ package Engine.GameEvents;
 import CommandingOfficers.Commander;
 import Engine.XYCoord;
 import Terrain.Environment;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.MapMaster;
 import Terrain.TerrainType;
 import UI.MapView;
@@ -52,7 +52,7 @@ public class CommanderDefeatEvent implements GameEvent
     defeatedCO.units.clear();
 
     // Downgrade the defeated commander's HQ to a city, unless they don't have a proper HQ.
-    Location HQLoc = gameMap.getLocation(defeatedCO.HQLocation);
+    MapLocation HQLoc = gameMap.getLocation(defeatedCO.HQLocation);
     if( HQLoc.getEnvironment().terrainType == TerrainType.HEADQUARTERS )
     {
       HQLoc.setEnvironment(Environment.getTile(TerrainType.CITY, HQLoc.getEnvironment().weatherType));
@@ -63,7 +63,7 @@ public class CommanderDefeatEvent implements GameEvent
     {
       for(int x = 0; x < gameMap.mapWidth; ++x)
       {
-        Location loc = gameMap.getLocation(x, y);
+        MapLocation loc = gameMap.getLocation(x, y);
 
         // Release control of any buildings he owned.
         if(loc.isCaptureable() && loc.getOwner() == defeatedCO)

--- a/src/Engine/GameEvents/CreateUnitEvent.java
+++ b/src/Engine/GameEvents/CreateUnitEvent.java
@@ -45,12 +45,13 @@ public class CreateUnitEvent implements GameEvent
   }
 
   @Override
-  public void sendToListener(GameEventListener listener)
+  public GameEventQueue sendToListener(GameEventListener listener)
   {
     if( null != myNewUnit )
     {
-      listener.receiveCreateUnitEvent(myNewUnit);
+      return listener.receiveCreateUnitEvent(myNewUnit);
     }
+    return null;
   }
 
   @Override

--- a/src/Engine/GameEvents/GameEvent.java
+++ b/src/Engine/GameEvents/GameEvent.java
@@ -21,7 +21,7 @@ public interface GameEvent
    * to the correct receivers in GameEventListener subclasses.
    * @param listener The visitor who wishes to receive GameEvents.
    */
-  public void sendToListener(GameEventListener listener);
+  public GameEventQueue sendToListener(GameEventListener listener);
 
   /**
    * Hook for subclasses to implement the specific effects of each action type.

--- a/src/Engine/GameEvents/GameEventListener.java
+++ b/src/Engine/GameEvents/GameEventListener.java
@@ -12,7 +12,7 @@ import Engine.UnitActionLifecycles.JoinLifecycle;
 import Engine.UnitActionLifecycles.LoadLifecycle;
 import Engine.UnitActionLifecycles.UnloadLifecycle;
 import Terrain.Environment.Weathers;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Units.Unit;
 import Units.UnitModel;
 
@@ -71,7 +71,7 @@ public interface GameEventListener extends Serializable
   default public GameEventQueue receiveBattleEvent(BattleSummary summary){ return null; };
   default public GameEventQueue receiveDemolitionEvent(Unit actor, XYCoord tile){ return null; };
   default public GameEventQueue receiveCreateUnitEvent(Unit unit){ return null; };
-  default public GameEventQueue receiveCaptureEvent(Unit unit, Location location){ return null; };
+  default public GameEventQueue receiveCaptureEvent(Unit unit, MapLocation location){ return null; };
   default public GameEventQueue receiveCommanderDefeatEvent(CommanderDefeatEvent event){ return null; };
   default public GameEventQueue receiveLoadEvent(LoadLifecycle.LoadEvent event){ return null; };
   default public GameEventQueue receiveMoveEvent(MoveEvent event){ return null; };

--- a/src/Engine/GameEvents/GameEventListener.java
+++ b/src/Engine/GameEvents/GameEventListener.java
@@ -22,22 +22,25 @@ import Units.UnitModel;
  * override those receive functions they care about.
  * We use the visitor pattern to call the correct event function whenever an event is distributed.
  */
-public abstract class GameEventListener implements Serializable
+public interface GameEventListener extends Serializable
 {
-  private static final long serialVersionUID = 1L;
-
-  /** Pass event along to every listener we still have. */
-  public static void publishEvent(GameEvent event, GameInstance gi)
+  /** Pass event along to every listener we still have. 
+   * @return */
+  public static GameEventQueue publishEvent(GameEvent event, GameInstance gi)
   {
+    GameEventQueue events = new GameEventQueue();
     for( GameEventListener gel : gi.eventListeners )
     {
       // The event will call the appropriate receive method in the listener.
-      event.sendToListener(gel);
+      GameEventQueue newEvents = event.sendToListener(gel);
+      if( null != newEvents )
+        events.addAll(newEvents);
     }
+    return events;
   }
 
   /** Allows GameInstance to make informed decisons on whether to try saving this listener */
-  public boolean shouldSerialize() { return true; }
+  default public boolean shouldSerialize() { return true; }
 
   /** Sign this listener up to receive events. If a listener registers multiple times, it will still
    *  receive each notification only once. */
@@ -46,7 +49,7 @@ public abstract class GameEventListener implements Serializable
     listener.registerForEvents(gi);
   }
 
-  public void registerForEvents(GameInstance gi)
+  default public void registerForEvents(GameInstance gi)
   {
     gi.eventListeners.add(this);
   }
@@ -58,31 +61,31 @@ public abstract class GameEventListener implements Serializable
     listener.unregister(gi);
   }
 
-  public void unregister(GameInstance gi)
+  default public void unregister(GameInstance gi)
   {
     gi.eventListeners.remove(this);
   }
 
   // The functions below should be overridden by subclasses for event types they care about.
   // As a rule, we should avoid passing the actual event to the receive hooks when possible.
-  public void receiveBattleEvent(BattleSummary summary){};
-  public void receiveDemolitionEvent(Unit actor, XYCoord tile){};
-  public void receiveCreateUnitEvent(Unit unit){};
-  public void receiveCaptureEvent(Unit unit, Location location){};
-  public void receiveCommanderDefeatEvent(CommanderDefeatEvent event){};
-  public void receiveLoadEvent(LoadLifecycle.LoadEvent event){};
-  public void receiveMoveEvent(MoveEvent event){};
-  public void receiveTeleportEvent(Unit teleporter, XYCoord from, XYCoord to){};
-  public void receiveTurnInitEvent(Commander co, int turn){};
-  public void receiveUnitJoinEvent(JoinLifecycle.JoinEvent event){};
-  public void receiveResupplyEvent(ResupplyEvent event){};
-  public void receiveUnitDieEvent(Unit victim, XYCoord grave, Integer hpBeforeDeath){};
-  public void receiveUnloadEvent(UnloadLifecycle.UnloadEvent event){};
-  public void receiveUnitTransformEvent(Unit unit, UnitModel oldType){};
-  public void receiveTerrainChangeEvent(ArrayList<EnvironmentAssignment> terrainChanges){};
-  public void receiveWeatherChangeEvent(Weathers weather, int duration){};
-  public void receiveMapChangeEvent(MapChangeEvent event){};
-  public void receiveMassDamageEvent(Commander attacker, Map<Unit, Integer> lostHP){};
-  public void receiveModifyFundsEvent(Commander beneficiary, int fundsDelta){};
+  default public GameEventQueue receiveBattleEvent(BattleSummary summary){ return null; };
+  default public GameEventQueue receiveDemolitionEvent(Unit actor, XYCoord tile){ return null; };
+  default public GameEventQueue receiveCreateUnitEvent(Unit unit){ return null; };
+  default public GameEventQueue receiveCaptureEvent(Unit unit, Location location){ return null; };
+  default public GameEventQueue receiveCommanderDefeatEvent(CommanderDefeatEvent event){ return null; };
+  default public GameEventQueue receiveLoadEvent(LoadLifecycle.LoadEvent event){ return null; };
+  default public GameEventQueue receiveMoveEvent(MoveEvent event){ return null; };
+  default public GameEventQueue receiveTeleportEvent(Unit teleporter, XYCoord from, XYCoord to){ return null; };
+  default public GameEventQueue receiveTurnInitEvent(Commander co, int turn){ return null; };
+  default public GameEventQueue receiveUnitJoinEvent(JoinLifecycle.JoinEvent event){ return null; };
+  default public GameEventQueue receiveResupplyEvent(ResupplyEvent event){ return null; };
+  default public GameEventQueue receiveUnitDieEvent(Unit victim, XYCoord grave, Integer hpBeforeDeath){ return null; };
+  default public GameEventQueue receiveUnloadEvent(UnloadLifecycle.UnloadEvent event){ return null; };
+  default public GameEventQueue receiveUnitTransformEvent(Unit unit, UnitModel oldType){ return null; };
+  default public GameEventQueue receiveTerrainChangeEvent(ArrayList<EnvironmentAssignment> terrainChanges){ return null; };
+  default public GameEventQueue receiveWeatherChangeEvent(Weathers weather, int duration){ return null; };
+  default public GameEventQueue receiveMapChangeEvent(MapChangeEvent event){ return null; };
+  default public GameEventQueue receiveMassDamageEvent(Commander attacker, Map<Unit, Integer> lostHP){ return null; };
+  default public GameEventQueue receiveModifyFundsEvent(Commander beneficiary, int fundsDelta){ return null; };
 
 }

--- a/src/Engine/GameEvents/GlobalWeatherEvent.java
+++ b/src/Engine/GameEvents/GlobalWeatherEvent.java
@@ -35,9 +35,9 @@ public class GlobalWeatherEvent implements GameEvent
   }
 
   @Override
-  public void sendToListener(GameEventListener listener)
+  public GameEventQueue sendToListener(GameEventListener listener)
   {
-    listener.receiveWeatherChangeEvent(weather, duration);
+    return listener.receiveWeatherChangeEvent(weather, duration);
   }
 
   @Override

--- a/src/Engine/GameEvents/GlobalWeatherEvent.java
+++ b/src/Engine/GameEvents/GlobalWeatherEvent.java
@@ -2,7 +2,7 @@ package Engine.GameEvents;
 
 import Engine.XYCoord;
 import Terrain.Environment.Weathers;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.MapMaster;
 import UI.MapView;
 import UI.Art.Animation.GameAnimation;
@@ -47,7 +47,7 @@ public class GlobalWeatherEvent implements GameEvent
     {
       for( int x = 0; x < gameMap.mapWidth; ++x )
       {
-        Location loc = gameMap.getLocation(x, y);
+        MapLocation loc = gameMap.getLocation(x, y);
         loc.setForecast(weather, (gameMap.commanders.length * duration) - 1);
       }
     }

--- a/src/Engine/GameEvents/HealUnitEvent.java
+++ b/src/Engine/GameEvents/HealUnitEvent.java
@@ -27,9 +27,10 @@ public class HealUnitEvent implements GameEvent
   }
 
   @Override
-  public void sendToListener(GameEventListener listener)
+  public GameEventQueue sendToListener(GameEventListener listener)
   {
     // TODO: Consider making all repairs/healing go through this event before making a listen event for this
+    return null;
   }
 
   @Override

--- a/src/Engine/GameEvents/MapChangeEvent.java
+++ b/src/Engine/GameEvents/MapChangeEvent.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 
 import Engine.XYCoord;
 import Terrain.Environment;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.MapMaster;
 import UI.MapView;
 import UI.Art.Animation.GameAnimation;
@@ -46,7 +46,7 @@ public class MapChangeEvent implements GameEvent
   {
     for( EnvironmentAssignment ea : changes )
     {
-      Location loc = gameMap.getLocation(ea.where);
+      MapLocation loc = gameMap.getLocation(ea.where);
       if( null != loc )
       {
         if( loc.getEnvironment().terrainType != ea.environment.terrainType )

--- a/src/Engine/GameEvents/MapChangeEvent.java
+++ b/src/Engine/GameEvents/MapChangeEvent.java
@@ -26,6 +26,8 @@ public class MapChangeEvent implements GameEvent
   /** Allows changing a set of tiles all at once. */
   public MapChangeEvent(ArrayList<EnvironmentAssignment> envChanges)
   {
+    if( envChanges.size() < 1 )
+      System.out.println("Warning: Generating a MapChangeEvent with no changes to the map.");
     changes = envChanges;
   }
 

--- a/src/Engine/GameEvents/MapChangeEvent.java
+++ b/src/Engine/GameEvents/MapChangeEvent.java
@@ -36,9 +36,9 @@ public class MapChangeEvent implements GameEvent
   }
 
   @Override
-  public void sendToListener(GameEventListener listener)
+  public GameEventQueue sendToListener(GameEventListener listener)
   {
-    listener.receiveTerrainChangeEvent(changes);
+    return listener.receiveTerrainChangeEvent(changes);
   }
 
   @Override

--- a/src/Engine/GameEvents/MapChangeEvent.java
+++ b/src/Engine/GameEvents/MapChangeEvent.java
@@ -61,13 +61,17 @@ public class MapChangeEvent implements GameEvent
   @Override
   public XYCoord getStartPoint()
   {
-    return changes.get(0).where;
+    if( changes.size() > 0 )
+      return changes.get(0).where;
+    return null;
   }
 
   @Override
   public XYCoord getEndPoint()
   {
-    return changes.get(0).where;
+    if( changes.size() > 0 )
+      return changes.get(0).where;
+    return null;
   }
 
   public static class EnvironmentAssignment

--- a/src/Engine/GameEvents/MassDamageEvent.java
+++ b/src/Engine/GameEvents/MassDamageEvent.java
@@ -42,9 +42,9 @@ public class MassDamageEvent implements GameEvent
   }
 
   @Override
-  public void sendToListener(GameEventListener listener)
+  public GameEventQueue sendToListener(GameEventListener listener)
   {
-    listener.receiveMassDamageEvent(attacker, victims);
+    return listener.receiveMassDamageEvent(attacker, victims);
   }
 
   @Override

--- a/src/Engine/GameEvents/ModifyFundsEvent.java
+++ b/src/Engine/GameEvents/ModifyFundsEvent.java
@@ -25,9 +25,9 @@ public class ModifyFundsEvent implements GameEvent
   }
 
   @Override
-  public void sendToListener(GameEventListener listener)
+  public GameEventQueue sendToListener(GameEventListener listener)
   {
-    listener.receiveModifyFundsEvent(beneficiary, value);
+    return listener.receiveModifyFundsEvent(beneficiary, value);
   }
 
   @Override

--- a/src/Engine/GameEvents/MoveEvent.java
+++ b/src/Engine/GameEvents/MoveEvent.java
@@ -1,7 +1,7 @@
 package Engine.GameEvents;
 
 import CommandingOfficers.Commander;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.XYCoord;
 import Terrain.MapMaster;
 import UI.MapView;
@@ -17,9 +17,9 @@ import Units.Unit;
 public class MoveEvent implements GameEvent
 {
   private Unit unit = null;
-  private Path unitPath = null;
+  private GamePath unitPath = null;
 
-  public MoveEvent(Unit u, Path path)
+  public MoveEvent(Unit u, GamePath path)
   {
     unit = u;
     unitPath = path;
@@ -42,7 +42,7 @@ public class MoveEvent implements GameEvent
   {
     if( unitPath.getPathLength() > 0 ) // Make sure we have a destination.
     {
-      Path.PathNode endpoint = unitPath.getEnd();
+      GamePath.PathNode endpoint = unitPath.getEnd();
       int fuelBurn = unitPath.getFuelCost(unit.model, gameMap);
 
       boolean includeOccupiedSpaces = true; // To allow validation for LOAD/JOIN actions.

--- a/src/Engine/GameEvents/MoveEvent.java
+++ b/src/Engine/GameEvents/MoveEvent.java
@@ -32,9 +32,9 @@ public class MoveEvent implements GameEvent
   }
 
   @Override
-  public void sendToListener(GameEventListener listener)
+  public GameEventQueue sendToListener(GameEventListener listener)
   {
-    listener.receiveMoveEvent(this);
+    return listener.receiveMoveEvent(this);
   }
 
   @Override

--- a/src/Engine/GameEvents/ResupplyEvent.java
+++ b/src/Engine/GameEvents/ResupplyEvent.java
@@ -23,9 +23,9 @@ public class ResupplyEvent implements GameEvent
   }
 
   @Override
-  public void sendToListener(GameEventListener listener)
+  public GameEventQueue sendToListener(GameEventListener listener)
   {
-    listener.receiveResupplyEvent( this );
+    return listener.receiveResupplyEvent( this );
   }
 
   @Override

--- a/src/Engine/GameEvents/TeleportEvent.java
+++ b/src/Engine/GameEvents/TeleportEvent.java
@@ -62,9 +62,9 @@ public class TeleportEvent implements GameEvent
   }
 
   @Override
-  public void sendToListener(GameEventListener listener)
+  public GameEventQueue sendToListener(GameEventListener listener)
   {
-    listener.receiveTeleportEvent(unit, unitStart, unitDestination);
+    return listener.receiveTeleportEvent(unit, unitStart, unitDestination);
   }
 
   @Override

--- a/src/Engine/GameEvents/TurnInitEvent.java
+++ b/src/Engine/GameEvents/TurnInitEvent.java
@@ -45,9 +45,9 @@ public class TurnInitEvent implements GameEvent
   }
 
   @Override
-  public void sendToListener(GameEventListener listener)
+  public GameEventQueue sendToListener(GameEventListener listener)
   {
-    listener.receiveTurnInitEvent(cmdr, turn);
+    return listener.receiveTurnInitEvent(cmdr, turn);
   }
 
   @Override

--- a/src/Engine/GameEvents/UnitDieEvent.java
+++ b/src/Engine/GameEvents/UnitDieEvent.java
@@ -26,9 +26,9 @@ public class UnitDieEvent implements GameEvent
   }
 
   @Override
-  public void sendToListener(GameEventListener listener)
+  public GameEventQueue sendToListener(GameEventListener listener)
   {
-    listener.receiveUnitDieEvent( unit, where, hpBeforeDeath );
+    return listener.receiveUnitDieEvent( unit, where, hpBeforeDeath );
   }
 
   @Override

--- a/src/Engine/GameInput/DefaultState.java
+++ b/src/Engine/GameInput/DefaultState.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 
 import Engine.XYCoord;
 import Engine.GameInput.GameInputHandler.InputType;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Units.Unit;
 import Units.UnitModel;
 
@@ -30,7 +30,7 @@ class DefaultState extends GameInputState<XYCoord>
   public GameInputState<?> select(XYCoord coord)
   {
     GameInputState<?> next = this;
-    Location loc = myStateData.gameMap.getLocation(coord);
+    MapLocation loc = myStateData.gameMap.getLocation(coord);
     Unit resident = loc.getResident();
     if( null != resident
         && (!resident.isTurnOver    // If it's our unit and the unit is ready to go.

--- a/src/Engine/GameInput/GameInputState.java
+++ b/src/Engine/GameInput/GameInputState.java
@@ -8,7 +8,7 @@ import CommandingOfficers.Commander;
 import Engine.GameAction;
 import Engine.GameActionSet;
 import Engine.OptionSelector;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.XYCoord;
 import Engine.Combat.DamagePopup;
 import Engine.GameInput.GameInputHandler.InputType;
@@ -101,7 +101,7 @@ abstract class GameInputState<T>
     public Unit unitLauncher = null;
     public XYCoord unitCoord = null;
     public GameActionSet actionSet = null;
-    public Path path = null;
+    public GamePath path = null;
     public ArrayList<? extends Object> menuOptions = null; // Just require a toString().
     public Map<Unit, XYCoord> unitLocationMap = null; // Used to map units to unload locations.
     public Collection<DamagePopup> damagePopups = new ArrayList<DamagePopup>();

--- a/src/Engine/GameInput/SelectMoveLocation.java
+++ b/src/Engine/GameInput/SelectMoveLocation.java
@@ -2,7 +2,7 @@ package Engine.GameInput;
 
 import java.util.ArrayList;
 
-import Engine.Path;
+import Engine.GamePath;
 import Engine.Utils;
 import Engine.XYCoord;
 import Engine.GameInput.GameInputHandler.InputType;
@@ -68,7 +68,7 @@ class SelectMoveLocation extends GameInputState<XYCoord>
 
     data.unitActor = mover;
     data.unitCoord = startCoord;
-    data.path = new Path();
+    data.path = new GamePath();
 
     SelectMoveLocation next = new SelectMoveLocation(data);
     next.oldUnitCoord = oldUnitCoord;
@@ -91,7 +91,7 @@ class SelectMoveLocation extends GameInputState<XYCoord>
   {
     if( null == myStateData.path )
     {
-      myStateData.path = new Path();
+      myStateData.path = new GamePath();
     }
 
     // If the new point already exists on the path, cut the extraneous points out.

--- a/src/Engine/GameInstance.java
+++ b/src/Engine/GameInstance.java
@@ -16,7 +16,7 @@ import Engine.GameEvents.MapChangeEvent;
 import Engine.GameEvents.TurnInitEvent;
 import Terrain.Environment;
 import Terrain.Environment.Weathers;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.MapMaster;
 import Terrain.MapWindow;
 
@@ -135,7 +135,7 @@ public class GameInstance implements Serializable
   {
     return new XYCoord(cursorX, cursorY);
   }
-  public Location getCursorLocation()
+  public MapLocation getCursorLocation()
   {
     return gameMap.getLocation(cursorX, cursorY);
   }
@@ -210,7 +210,7 @@ public class GameInstance implements Serializable
     {
       for( int j = 0; j < gameMap.mapHeight; j++ )
       {
-        Location loc = gameMap.getLocation(i, j);
+        MapLocation loc = gameMap.getLocation(i, j);
         if( loc.forecast.isEmpty() )
         {
           if( loc.getEnvironment().weatherType != defaultWeather )

--- a/src/Engine/GameInstance.java
+++ b/src/Engine/GameInstance.java
@@ -18,7 +18,7 @@ import Terrain.Environment;
 import Terrain.Environment.Weathers;
 import Terrain.MapLocation;
 import Terrain.MapMaster;
-import Terrain.MapFog;
+import Terrain.MapPerspective;
 
 public class GameInstance implements Serializable
 {
@@ -71,7 +71,7 @@ public class GameInstance implements Serializable
       commanders[i].money = gameScenario.rules.startingFunds;
       if( commanders[i].HQLocation != null )
       {
-        commanders[i].myView = new MapFog(map, commanders[i]);
+        commanders[i].myView = new MapPerspective(map, commanders[i]);
         commanders[i].myView.resetFog();
         playerCursors.put(i, commanders[i].HQLocation);
       }

--- a/src/Engine/GameInstance.java
+++ b/src/Engine/GameInstance.java
@@ -18,7 +18,7 @@ import Terrain.Environment;
 import Terrain.Environment.Weathers;
 import Terrain.MapLocation;
 import Terrain.MapMaster;
-import Terrain.MapWindow;
+import Terrain.MapFog;
 
 public class GameInstance implements Serializable
 {
@@ -71,7 +71,7 @@ public class GameInstance implements Serializable
       commanders[i].money = gameScenario.rules.startingFunds;
       if( commanders[i].HQLocation != null )
       {
-        commanders[i].myView = new MapWindow(map, commanders[i]);
+        commanders[i].myView = new MapFog(map, commanders[i]);
         commanders[i].myView.resetFog();
         playerCursors.put(i, commanders[i].HQLocation);
       }

--- a/src/Engine/GamePath.java
+++ b/src/Engine/GamePath.java
@@ -9,12 +9,12 @@ import Units.UnitModel;
 /**
  * Path stores a list of waypoints.
  */
-public class Path
+public class GamePath
 {
 
   private ArrayList<PathNode> waypoints;
 
-  public Path()
+  public GamePath()
   {
     waypoints = new ArrayList<PathNode>();
   }

--- a/src/Engine/MapController.java
+++ b/src/Engine/MapController.java
@@ -9,7 +9,7 @@ import Engine.GameEvents.GameEventListener;
 import Engine.GameEvents.GameEventQueue;
 import Engine.GameEvents.TurnInitEvent;
 import Engine.GameInput.GameInputHandler;
-import Terrain.Location;
+import Terrain.MapLocation;
 import UI.CO_InfoController;
 import UI.GameStatsController;
 import UI.InGameMenu;
@@ -210,7 +210,7 @@ public class MapController implements IController, GameInputHandler.StateChanged
         if( !myGameInputHandler.isTargeting() )
         {
           // If we hit BACK while over a unit, add it to the threat overlay for this CO
-          Location loc = myGame.gameMap.getLocation(myGame.getCursorCoord());
+          MapLocation loc = myGame.gameMap.getLocation(myGame.getCursorCoord());
           Unit resident = loc.getResident();
           if( null != resident )
           {

--- a/src/Engine/MapController.java
+++ b/src/Engine/MapController.java
@@ -3,7 +3,6 @@ package Engine;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import CommandingOfficers.Commander;
 import Engine.Combat.DamagePopup;
 import Engine.GameEvents.GameEvent;
 import Engine.GameEvents.GameEventListener;
@@ -520,21 +519,11 @@ public class MapController implements IController, GameInputHandler.StateChanged
       event.performEvent(myGame.gameMap);
 
       // Now that the event has been completed, let the world know.
-      GameEventListener.publishEvent(event, myGame);
-    }
-
-    if( animEventQueueIsEmpty )
-    {
-      for( Commander co : myGame.commanders )
+      GameEventQueue events = GameEventListener.publishEvent(event, myGame);
+      if( !events.isEmpty() )
       {
-        GameEventQueue events = new GameEventQueue();
-        co.pollForEvents(events);
-        if( !events.isEmpty() )
-        {
-          animEventQueueIsEmpty = false;
-          myView.animate(events);
-          break; // We'll get the next commander the next time we hit this block.
-        }
+        animEventQueueIsEmpty = false;
+        myView.animate(events);
       }
     }
 

--- a/src/Engine/MapController.java
+++ b/src/Engine/MapController.java
@@ -390,7 +390,7 @@ public class MapController implements IController, GameInputHandler.StateChanged
       case PATH_SELECT:
         break; // no special behavior
       case MENU_SELECT:
-        Path path = myGameInputHandler.myStateData.path;
+        GamePath path = myGameInputHandler.myStateData.path;
         if( null != path && path.getPathLength() > 0 )
         {
           myGame.setCursorLocation(path.getEnd().GetCoordinates());
@@ -625,7 +625,7 @@ public class MapController implements IController, GameInputHandler.StateChanged
     return myGameInputHandler.getUnitCoord();
   }
 
-  public Path getContemplatedMove()
+  public GamePath getContemplatedMove()
   {
     return myGameInputHandler.myStateData.path;
   }

--- a/src/Engine/UnitActionFactory.java
+++ b/src/Engine/UnitActionFactory.java
@@ -19,11 +19,11 @@ public abstract class UnitActionFactory implements Serializable
 {
   private static final long serialVersionUID = 1L;
 
-  public GameActionSet getPossibleActions(GameMap map, Path movePath, Unit actor)
+  public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor)
   {
     return getPossibleActions(map, movePath, actor, false);
   }
-  public abstract GameActionSet getPossibleActions(GameMap map, Path movePath, Unit actor, boolean ignoreResident);
+  public abstract GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident);
   public abstract String name();
   public boolean shouldConfirm = false;
 

--- a/src/Engine/UnitActionLifecycles/BattleLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/BattleLifecycle.java
@@ -21,7 +21,7 @@ import Engine.GameEvents.GameEventQueue;
 import Engine.GameEvents.MapChangeEvent;
 import Terrain.Environment;
 import Terrain.GameMap;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.MapMaster;
 import Terrain.TerrainType;
 import UI.MapView;
@@ -239,7 +239,7 @@ public abstract class BattleLifecycle
     private XYCoord moveCoord = null;
     private XYCoord attackLocation = null;
     private Unit attacker;
-    private Location target;
+    private MapLocation target;
 
     public DemolitionAction(GameMap gameMap, Unit actor, GamePath path, XYCoord atkLoc)
     {
@@ -435,9 +435,9 @@ public abstract class BattleLifecycle
   {
     private final StrikeParams result;
     private final int percentDamage;
-    private final Location target;
+    private final MapLocation target;
 
-    public DemolitionEvent(Unit attacker, Location target, GamePath path, MapMaster map)
+    public DemolitionEvent(Unit attacker, MapLocation target, GamePath path, MapMaster map)
     {
       this.target = target;
       // Calculate the result of the battle immediately. This will allow us to plan the animation.
@@ -450,7 +450,7 @@ public abstract class BattleLifecycle
       return result.attacker.body;
     }
 
-    public Location getDefender()
+    public MapLocation getDefender()
     {
       return target;
     }

--- a/src/Engine/UnitActionLifecycles/BattleLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/BattleLifecycle.java
@@ -19,7 +19,6 @@ import Engine.GameEvents.GameEvent;
 import Engine.GameEvents.GameEventListener;
 import Engine.GameEvents.GameEventQueue;
 import Engine.GameEvents.MapChangeEvent;
-import Engine.GameEvents.UnitDieEvent;
 import Terrain.Environment;
 import Terrain.GameMap;
 import Terrain.Location;
@@ -397,9 +396,9 @@ public abstract class BattleLifecycle
     }
 
     @Override
-    public void sendToListener(GameEventListener listener)
+    public GameEventQueue sendToListener(GameEventListener listener)
     {
-      listener.receiveBattleEvent(battleInfo);
+      return listener.receiveBattleEvent(battleInfo);
     }
 
     @Override
@@ -467,9 +466,9 @@ public abstract class BattleLifecycle
     }
 
     @Override
-    public void sendToListener(GameEventListener listener)
+    public GameEventQueue sendToListener(GameEventListener listener)
     {
-      listener.receiveDemolitionEvent(result.attacker.body, target.getCoordinates());
+      return listener.receiveDemolitionEvent(result.attacker.body, target.getCoordinates());
     }
 
     @Override

--- a/src/Engine/UnitActionLifecycles/BattleLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/BattleLifecycle.java
@@ -6,7 +6,7 @@ import java.util.HashSet;
 
 import Engine.GameAction;
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.Utils;
 import Engine.XYCoord;
@@ -36,7 +36,7 @@ public abstract class BattleLifecycle
     private static final long serialVersionUID = 1L;
 
     @Override
-    public GameActionSet getPossibleActions(GameMap map, Path movePath, Unit actor, boolean ignoreResident)
+    public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
     {
       XYCoord moveLocation = movePath.getEndCoord();
       if( ignoreResident || map.isLocationEmpty(actor, moveLocation) )
@@ -94,18 +94,18 @@ public abstract class BattleLifecycle
 
   public static class BattleAction extends GameAction
   {
-    private Path movePath;
+    private GamePath movePath;
     private XYCoord moveCoord = null;
     private XYCoord attackLocation = null;
     private Unit attacker;
     private Unit defender;
 
-    public BattleAction(GameMap gameMap, Unit actor, Path path, int targetX, int targetY)
+    public BattleAction(GameMap gameMap, Unit actor, GamePath path, int targetX, int targetY)
     {
       this(gameMap, actor, path, new XYCoord(targetX, targetY));
     }
 
-    public BattleAction(GameMap gameMap, Unit actor, Path path, XYCoord atkLoc)
+    public BattleAction(GameMap gameMap, Unit actor, GamePath path, XYCoord atkLoc)
     {
       movePath = path;
       attacker = actor;
@@ -235,13 +235,13 @@ public abstract class BattleLifecycle
 
   public static class DemolitionAction extends GameAction
   {
-    private Path movePath;
+    private GamePath movePath;
     private XYCoord moveCoord = null;
     private XYCoord attackLocation = null;
     private Unit attacker;
     private Location target;
 
-    public DemolitionAction(GameMap gameMap, Unit actor, Path path, XYCoord atkLoc)
+    public DemolitionAction(GameMap gameMap, Unit actor, GamePath path, XYCoord atkLoc)
     {
       movePath = path;
       attacker = actor;
@@ -363,7 +363,7 @@ public abstract class BattleLifecycle
     private final BattleSummary battleInfo;
     private final XYCoord defenderCoords;
 
-    public BattleEvent(Unit attacker, Unit defender, Path path, MapMaster map)
+    public BattleEvent(Unit attacker, Unit defender, GamePath path, MapMaster map)
     {
       boolean attackerMoved = path.getPathLength() > 1;
       // Calculate the result of the battle immediately. This will allow us to plan the animation.
@@ -437,7 +437,7 @@ public abstract class BattleLifecycle
     private final int percentDamage;
     private final Location target;
 
-    public DemolitionEvent(Unit attacker, Location target, Path path, MapMaster map)
+    public DemolitionEvent(Unit attacker, Location target, GamePath path, MapMaster map)
     {
       this.target = target;
       // Calculate the result of the battle immediately. This will allow us to plan the animation.

--- a/src/Engine/UnitActionLifecycles/CaptureLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/CaptureLifecycle.java
@@ -2,7 +2,7 @@ package Engine.UnitActionLifecycles;
 
 import Engine.GameAction;
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.Utils;
 import Engine.XYCoord;
@@ -25,7 +25,7 @@ public abstract class CaptureLifecycle
     private static final long serialVersionUID = 1L;
 
     @Override
-    public GameActionSet getPossibleActions(GameMap map, Path movePath, Unit actor, boolean ignoreResident)
+    public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
     {
       XYCoord moveLocation = movePath.getEndCoord();
       if( ignoreResident || map.isLocationEmpty(actor, moveLocation) )
@@ -57,11 +57,11 @@ public abstract class CaptureLifecycle
   public static class CaptureAction extends GameAction
   {
     private Unit actor = null;
-    private Path movePath;
+    private GamePath movePath;
     private XYCoord movePathEnd;
     private TerrainType propertyType;
 
-    public CaptureAction(GameMap gameMap, Unit unit, Path path)
+    public CaptureAction(GameMap gameMap, Unit unit, GamePath path)
     {
       actor = unit;
       movePath = path;

--- a/src/Engine/UnitActionLifecycles/CaptureLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/CaptureLifecycle.java
@@ -11,7 +11,7 @@ import Engine.GameEvents.GameEvent;
 import Engine.GameEvents.GameEventListener;
 import Engine.GameEvents.GameEventQueue;
 import Terrain.GameMap;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.MapMaster;
 import Terrain.TerrainType;
 import UI.MapView;
@@ -85,7 +85,7 @@ public abstract class CaptureLifecycle
       GameEventQueue captureEvents = new GameEventQueue();
 
       // Validate input
-      Location captureLocation = null;
+      MapLocation captureLocation = null;
       boolean isValid = true;
       isValid &= null != actor && !actor.isTurnOver; // Valid unit
       isValid &= null != map; // Valid map
@@ -158,11 +158,11 @@ public abstract class CaptureLifecycle
   public static class CaptureEvent implements GameEvent
   {
   private Unit unit = null;
-  private Location location = null;
+  private MapLocation location = null;
   final int captureAmount;
   final int priorCaptureAmount;
 
-  public CaptureEvent( Unit u, Location loc )
+  public CaptureEvent( Unit u, MapLocation loc )
   {
     unit = u;
     location = loc;

--- a/src/Engine/UnitActionLifecycles/CaptureLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/CaptureLifecycle.java
@@ -187,9 +187,9 @@ public abstract class CaptureLifecycle
   }
 
   @Override
-  public void sendToListener(GameEventListener listener)
+  public GameEventQueue sendToListener(GameEventListener listener)
   {
-    listener.receiveCaptureEvent( unit, location );
+    return listener.receiveCaptureEvent( unit, location );
   }
 
   public boolean willCapture()

--- a/src/Engine/UnitActionLifecycles/DeleteLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/DeleteLifecycle.java
@@ -2,7 +2,7 @@ package Engine.UnitActionLifecycles;
 
 import Engine.GameAction;
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.Utils;
 import Engine.XYCoord;
@@ -26,7 +26,7 @@ public abstract class DeleteLifecycle
     }
 
     @Override
-    public GameActionSet getPossibleActions(GameMap map, Path movePath, Unit actor, boolean ignoreResident)
+    public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
     {
       XYCoord moveLocation = movePath.getEndCoord();
       if( moveLocation.equals(actor.x, actor.y) )

--- a/src/Engine/UnitActionLifecycles/ExplodeLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/ExplodeLifecycle.java
@@ -5,7 +5,7 @@ import java.util.Collection;
 import java.util.HashSet;
 
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.Utils;
 import Engine.XYCoord;
@@ -39,7 +39,7 @@ public abstract class ExplodeLifecycle
     }
 
     @Override
-    public GameActionSet getPossibleActions(GameMap map, Path movePath, Unit actor, boolean ignoreResident)
+    public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
     {
       XYCoord moveLocation = movePath.getEndCoord();
       if( ignoreResident || map.isLocationEmpty(actor, moveLocation) )
@@ -62,7 +62,7 @@ public abstract class ExplodeLifecycle
     private ExplodeFactory type;
     Unit actor;
 
-    public ExplodeAction(Unit unit, Path path, ExplodeFactory pType)
+    public ExplodeAction(Unit unit, GamePath path, ExplodeFactory pType)
     {
       super(unit, path);
       type = pType;

--- a/src/Engine/UnitActionLifecycles/FlareLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/FlareLifecycle.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 
 import Engine.GameAction;
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.Utils;
 import Engine.XYCoord;
@@ -32,7 +32,7 @@ public abstract class FlareLifecycle
     }
 
     @Override
-    public GameActionSet getPossibleActions(GameMap map, Path movePath, Unit actor, boolean ignoreResident)
+    public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
     {
       XYCoord moveLocation = movePath.getEndCoord();
       if( ignoreResident || map.isLocationEmpty(actor, moveLocation) )
@@ -69,17 +69,17 @@ public abstract class FlareLifecycle
   public static class FlareAction extends GameAction
   {
     private FlareFactory type;
-    private Path movePath;
+    private GamePath movePath;
     private XYCoord moveCoord = null;
     private XYCoord launchLocation = null;
     private Unit actor;
 
-    public FlareAction(FlareFactory pType, Unit actor, Path path, int targetX, int targetY)
+    public FlareAction(FlareFactory pType, Unit actor, GamePath path, int targetX, int targetY)
     {
       this(pType, actor, path, new XYCoord(targetX, targetY));
     }
 
-    public FlareAction(FlareFactory pType, Unit actor, Path path, XYCoord atkLoc)
+    public FlareAction(FlareFactory pType, Unit actor, GamePath path, XYCoord atkLoc)
     {
       type = pType;
       movePath = path;

--- a/src/Engine/UnitActionLifecycles/FlareLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/FlareLifecycle.java
@@ -169,9 +169,10 @@ public abstract class FlareLifecycle
     }
 
     @Override
-    public void sendToListener(GameEventListener listener)
+    public GameEventQueue sendToListener(GameEventListener listener)
     {
       // TODO
+      return null;
     }
 
     @Override

--- a/src/Engine/UnitActionLifecycles/JoinLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/JoinLifecycle.java
@@ -2,7 +2,7 @@ package Engine.UnitActionLifecycles;
 
 import Engine.GameAction;
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.Utils;
 import Engine.XYCoord;
@@ -22,7 +22,7 @@ public abstract class JoinLifecycle
     private static final long serialVersionUID = 1L;
 
     @Override
-    public GameActionSet getPossibleActions(GameMap map, Path movePath, Unit actor, boolean ignoreResident)
+    public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
     {
       XYCoord moveLocation = movePath.getEndCoord();
       Unit resident = map.getLocation(moveLocation).getResident();
@@ -58,11 +58,11 @@ public abstract class JoinLifecycle
   public static class JoinAction extends GameAction
   {
     private Unit donor;
-    Path movePath;
+    GamePath movePath;
     private XYCoord pathEnd = null;
     private Unit recipient;
 
-    public JoinAction(GameMap gameMap, Unit actor, Path path)
+    public JoinAction(GameMap gameMap, Unit actor, GamePath path)
     {
       donor = actor;
       movePath = path;

--- a/src/Engine/UnitActionLifecycles/JoinLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/JoinLifecycle.java
@@ -166,9 +166,9 @@ public abstract class JoinLifecycle
     }
 
     @Override
-    public void sendToListener(GameEventListener listener)
+    public GameEventQueue sendToListener(GameEventListener listener)
     {
-      listener.receiveUnitJoinEvent(this);
+      return listener.receiveUnitJoinEvent(this);
     }
 
     @Override

--- a/src/Engine/UnitActionLifecycles/LaunchLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/LaunchLifecycle.java
@@ -3,7 +3,7 @@ package Engine.UnitActionLifecycles;
 import java.util.ArrayList;
 import Engine.GameAction;
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.Utils;
 import Engine.XYCoord;
@@ -23,7 +23,7 @@ public abstract class LaunchLifecycle
     private static final long serialVersionUID = 1L;
 
     @Override
-    public GameActionSet getPossibleActions(GameMap map, Path movePath, Unit actor, boolean ignoreResident)
+    public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
     {
       XYCoord moveLocation = movePath.getEndCoord();
       if( moveLocation.equals(actor.x, actor.y) )
@@ -50,7 +50,7 @@ public abstract class LaunchLifecycle
             // Build a launch action for each possible action the cargo can do after launch
             for( XYCoord coord : destinations )
             {
-              Path cargoMovePath = Utils.findShortestPath(cargo, coord, map);
+              GamePath cargoMovePath = Utils.findShortestPath(cargo, coord, map);
               ArrayList<GameActionSet> cargoActions = cargo.getPossibleActions(map, cargoMovePath, ignoreResident);
 
               for( GameActionSet actionSet : cargoActions )

--- a/src/Engine/UnitActionLifecycles/LaunchLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/LaunchLifecycle.java
@@ -183,8 +183,9 @@ public abstract class LaunchLifecycle
     }
 
     @Override
-    public void sendToListener(GameEventListener listener)
+    public GameEventQueue sendToListener(GameEventListener listener)
     {
+      return null;
     }
 
     @Override

--- a/src/Engine/UnitActionLifecycles/LoadLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/LoadLifecycle.java
@@ -2,7 +2,7 @@ package Engine.UnitActionLifecycles;
 
 import Engine.GameAction;
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.Utils;
 import Engine.XYCoord;
@@ -22,7 +22,7 @@ public abstract class LoadLifecycle
     private static final long serialVersionUID = 1L;
 
     @Override
-    public GameActionSet getPossibleActions(GameMap map, Path movePath, Unit actor, boolean ignoreResident)
+    public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
     {
       XYCoord moveLocation = movePath.getEndCoord();
       Unit resident = map.getLocation(moveLocation).getResident();
@@ -55,11 +55,11 @@ public abstract class LoadLifecycle
   public static class LoadAction extends GameAction
   {
     private Unit passenger;
-    Path movePath;
+    GamePath movePath;
     private XYCoord pathEnd = null;
     private Unit transport;
 
-    public LoadAction(GameMap gameMap, Unit actor, Path path)
+    public LoadAction(GameMap gameMap, Unit actor, GamePath path)
     {
       passenger = actor;
       movePath = path;

--- a/src/Engine/UnitActionLifecycles/LoadLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/LoadLifecycle.java
@@ -161,9 +161,9 @@ public abstract class LoadLifecycle
     }
 
     @Override
-    public void sendToListener(GameEventListener listener)
+    public GameEventQueue sendToListener(GameEventListener listener)
     {
-      listener.receiveLoadEvent(this);
+      return listener.receiveLoadEvent(this);
     }
 
     @Override

--- a/src/Engine/UnitActionLifecycles/RepairLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/RepairLifecycle.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 
 import Engine.GameAction;
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.Utils;
 import Engine.XYCoord;
@@ -22,7 +22,7 @@ public abstract class RepairLifecycle
     private static final long serialVersionUID = 1L;
 
     @Override
-    public GameActionSet getPossibleActions(GameMap map, Path movePath, Unit actor, boolean ignoreResident)
+    public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
     {
       XYCoord moveLocation = movePath.getEndCoord();
       if( ignoreResident || map.isLocationEmpty(actor, moveLocation) )
@@ -70,14 +70,14 @@ public abstract class RepairLifecycle
 
   public static class RepairUnitAction extends GameAction
   {
-    private Path movePath;
+    private GamePath movePath;
     private XYCoord startCoord;
     private XYCoord moveCoord;
     private XYCoord repairCoord;
     Unit benefactor;
     Unit beneficiary;
 
-    public RepairUnitAction(Unit actor, Path path, Unit target)
+    public RepairUnitAction(Unit actor, GamePath path, Unit target)
     {
       benefactor = actor;
       beneficiary = target;

--- a/src/Engine/UnitActionLifecycles/ResupplyLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/ResupplyLifecycle.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 
 import Engine.GameAction;
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.Utils;
 import Engine.XYCoord;
@@ -21,7 +21,7 @@ public abstract class ResupplyLifecycle
     private static final long serialVersionUID = 1L;
 
     @Override
-    public GameActionSet getPossibleActions(GameMap map, Path movePath, Unit actor, boolean ignoreResident)
+    public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
     {
       XYCoord moveLocation = movePath.getEndCoord();
       if( ignoreResident || map.isLocationEmpty(actor, moveLocation) )
@@ -65,14 +65,14 @@ public abstract class ResupplyLifecycle
   public static class ResupplyAction extends GameAction
   {
     private Unit unitActor = null;
-    private Path movePath = null;
+    private GamePath movePath = null;
 
     /**
      * Creates a resupply action to be executed from the end of path.
      * @param actor
      * @param path
      */
-    public ResupplyAction(Unit actor, Path path)
+    public ResupplyAction(Unit actor, GamePath path)
     {
       unitActor = actor;
       movePath = path;

--- a/src/Engine/UnitActionLifecycles/TerraformLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/TerraformLifecycle.java
@@ -1,7 +1,7 @@
 package Engine.UnitActionLifecycles;
 
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.XYCoord;
 import Engine.GameEvents.GameEvent;
@@ -30,7 +30,7 @@ public abstract class TerraformLifecycle
     }
 
     @Override
-    public GameActionSet getPossibleActions(GameMap map, Path movePath, Unit actor, boolean ignoreResident)
+    public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
     {
       XYCoord moveLocation = movePath.getEndCoord();
       if( ignoreResident || map.isLocationEmpty(actor, moveLocation) )
@@ -56,7 +56,7 @@ public abstract class TerraformLifecycle
     private Unit actor = null;
     private TerraformFactory type;
 
-    public TerraformAction(Unit unit, Path path, TerraformFactory pType)
+    public TerraformAction(Unit unit, GamePath path, TerraformFactory pType)
     {
       super(unit, path);
       actor = unit;

--- a/src/Engine/UnitActionLifecycles/TransformLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/TransformLifecycle.java
@@ -1,7 +1,7 @@
 package Engine.UnitActionLifecycles;
 
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.XYCoord;
 import Engine.GameEvents.GameEvent;
@@ -34,7 +34,7 @@ public abstract class TransformLifecycle
     }
 
     @Override
-    public GameActionSet getPossibleActions(GameMap map, Path movePath, Unit actor, boolean ignoreResident)
+    public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
     {
       XYCoord moveLocation = movePath.getEndCoord();
       if( ignoreResident || map.isLocationEmpty(actor, moveLocation) )
@@ -57,7 +57,7 @@ public abstract class TransformLifecycle
     private TransformFactory type;
     Unit actor;
 
-    public TransformAction(Unit unit, Path path, TransformFactory pType)
+    public TransformAction(Unit unit, GamePath path, TransformFactory pType)
     {
       super(unit, path);
       type = pType;

--- a/src/Engine/UnitActionLifecycles/TransformLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/TransformLifecycle.java
@@ -114,9 +114,9 @@ public abstract class TransformLifecycle
     }
 
     @Override
-    public void sendToListener(GameEventListener listener)
+    public GameEventQueue sendToListener(GameEventListener listener)
     {
-      listener.receiveUnitTransformEvent(unit, oldType);
+      return listener.receiveUnitTransformEvent(unit, oldType);
     }
 
     @Override

--- a/src/Engine/UnitActionLifecycles/UnitProduceLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/UnitProduceLifecycle.java
@@ -3,7 +3,7 @@ package Engine.UnitActionLifecycles;
 import CommandingOfficers.Commander;
 import Engine.GameAction;
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.XYCoord;
 import Engine.GameEvents.GameEvent;
@@ -29,7 +29,7 @@ public abstract class UnitProduceLifecycle
     }
 
     @Override
-    public GameActionSet getPossibleActions(GameMap map, Path movePath, Unit actor, boolean ignoreResident)
+    public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
     {
       XYCoord moveLocation = movePath.getEndCoord();
       if( moveLocation.equals(actor.x, actor.y) && actor.hasCargoSpace(typeToBuild.role) && actor.CO.money > typeToBuild.getCost()

--- a/src/Engine/UnitActionLifecycles/UnitProduceLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/UnitProduceLifecycle.java
@@ -129,12 +129,13 @@ public abstract class UnitProduceLifecycle
     }
 
     @Override
-    public void sendToListener(GameEventListener listener)
+    public GameEventQueue sendToListener(GameEventListener listener)
     {
       if( null != myNewUnit )
       {
-        listener.receiveCreateUnitEvent(myNewUnit);
+        return listener.receiveCreateUnitEvent(myNewUnit);
       }
+      return null;
     }
 
     @Override

--- a/src/Engine/UnitActionLifecycles/UnloadLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/UnloadLifecycle.java
@@ -219,9 +219,9 @@ public abstract class UnloadLifecycle
     }
 
     @Override
-    public void sendToListener(GameEventListener listener)
+    public GameEventQueue sendToListener(GameEventListener listener)
     {
-      listener.receiveUnloadEvent(this);
+      return listener.receiveUnloadEvent(this);
     }
 
     @Override

--- a/src/Engine/UnitActionLifecycles/UnloadLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/UnloadLifecycle.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import Engine.GameAction;
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.Utils;
 import Engine.XYCoord;
@@ -26,7 +26,7 @@ public abstract class UnloadLifecycle
     private static final long serialVersionUID = 1L;
 
     @Override
-    public GameActionSet getPossibleActions(GameMap map, Path movePath, Unit actor, boolean ignoreResident)
+    public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
     {
       XYCoord moveLocation = movePath.getEndCoord();
       if( ignoreResident || map.isLocationEmpty(actor, moveLocation) )
@@ -73,17 +73,17 @@ public abstract class UnloadLifecycle
   public static class UnloadAction extends GameAction
   {
     private Unit actor;
-    private Path movePath;
+    private GamePath movePath;
     private XYCoord moveLoc;
     private Map<Unit, XYCoord> myDropoffs;
     private XYCoord firstDropLoc;
 
-    public UnloadAction(GameMap gameMap, Unit actor, Path path, Unit passenger, int dropX, int dropY)
+    public UnloadAction(GameMap gameMap, Unit actor, GamePath path, Unit passenger, int dropX, int dropY)
     {
       this(actor, path, passenger, new XYCoord(dropX, dropY));
     }
 
-    public UnloadAction(Unit transport, Path movePath, final Unit passenger, final XYCoord dropLocation)
+    public UnloadAction(Unit transport, GamePath movePath, final Unit passenger, final XYCoord dropLocation)
     {
       this(transport, movePath, new HashMap<Unit, XYCoord>(){
         private static final long serialVersionUID = 1L;
@@ -93,7 +93,7 @@ public abstract class UnloadLifecycle
       });
     }
 
-    public UnloadAction(Unit transport, Path path, Map<Unit, XYCoord> dropoffs)
+    public UnloadAction(Unit transport, GamePath path, Map<Unit, XYCoord> dropoffs)
     {
       actor = transport;
       movePath = path;

--- a/src/Engine/UnitActionLifecycles/WaitLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/WaitLifecycle.java
@@ -2,7 +2,7 @@ package Engine.UnitActionLifecycles;
 
 import Engine.GameAction;
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.Utils;
 import Engine.XYCoord;
@@ -18,7 +18,7 @@ public abstract class WaitLifecycle
     private static final long serialVersionUID = 1L;
 
     @Override
-    public GameActionSet getPossibleActions(GameMap map, Path movePath, Unit actor, boolean ignoreResident)
+    public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
     {
       XYCoord moveLocation = movePath.getEndCoord();
       if( ignoreResident || map.isLocationEmpty(actor, moveLocation) )
@@ -46,11 +46,11 @@ public abstract class WaitLifecycle
 
   public static class WaitAction extends GameAction
   {
-    private final Path movePath;
+    private final GamePath movePath;
     private final XYCoord waitLoc;
     private final Unit actor;
 
-    public WaitAction(Unit unit, Path path)
+    public WaitAction(Unit unit, GamePath path)
     {
       actor = unit;
       movePath = path;
@@ -78,7 +78,7 @@ public abstract class WaitLifecycle
 
       if( isValid ) // Check fuel.
       {
-        Path.PathNode endpoint = movePath.getEnd();
+        GamePath.PathNode endpoint = movePath.getEnd();
         int fuelBurn = movePath.getFuelCost(actor.model, gameMap);
         boolean includeOccupiedSpaces = true; // To allow validation for LOAD/JOIN actions.
         isValid = fuelBurn <= actor.fuel && fuelBurn <= actor.model.movePower

--- a/src/Engine/Utils.java
+++ b/src/Engine/Utils.java
@@ -171,15 +171,15 @@ public class Utils
     return reachableTiles;
   }
 
-  public static boolean isPathValid(Unit unit, Path path, GameMap map, boolean includeOccupiedSpaces)
+  public static boolean isPathValid(Unit unit, GamePath path, GameMap map, boolean includeOccupiedSpaces)
   {
     return isPathValid(new XYCoord(unit.x, unit.y), unit, path, map, includeOccupiedSpaces);
   }
-  public static boolean isPathValid(XYCoord start, Unit unit, Path path, GameMap map, boolean includeOccupiedSpaces)
+  public static boolean isPathValid(XYCoord start, Unit unit, GamePath path, GameMap map, boolean includeOccupiedSpaces)
   {
     return isPathValid(start, unit.getMoveFunctor(includeOccupiedSpaces), Math.min(unit.model.movePower, unit.fuel), path, map);
   }
-  public static boolean isPathValid(XYCoord start, FloodFillFunctor fff, int initialFillPower, Path path, GameMap map)
+  public static boolean isPathValid(XYCoord start, FloodFillFunctor fff, int initialFillPower, GamePath path, GameMap map)
   {
     if( (null == path) || (null == fff) || (null == start) )
     {
@@ -212,32 +212,32 @@ public class Utils
   }
 
   /** Alias for {@link #findShortestPath(XYCoord, Unit, int, int, GameMap, boolean) findShortestPath(XYCoord, Unit, int, int, GameMap, boolean=false)} **/
-  public static Path findShortestPath(Unit unit, XYCoord destination, GameMap map, boolean theoretical)
+  public static GamePath findShortestPath(Unit unit, XYCoord destination, GameMap map, boolean theoretical)
   {
     return findShortestPath(unit, destination.xCoord, destination.yCoord, map, theoretical);
   }
   /** Alias for {@link #findShortestPath(XYCoord, Unit, int, int, GameMap, boolean) findShortestPath(XYCoord, Unit, int, int, GameMap, boolean=false)} **/
-  public static Path findShortestPath(Unit unit, int x, int y, GameMap map, boolean theoretical)
+  public static GamePath findShortestPath(Unit unit, int x, int y, GameMap map, boolean theoretical)
   {
     return findShortestPath(new XYCoord(unit.x, unit.y), unit, x, y, map, theoretical);
   }
   /** Alias for {@link #findShortestPath(XYCoord, Unit, int, int, GameMap, boolean) findShortestPath(XYCoord, Unit, int, int, GameMap, boolean=false)} **/
-  public static Path findShortestPath(Unit unit, XYCoord destination, GameMap map)
+  public static GamePath findShortestPath(Unit unit, XYCoord destination, GameMap map)
   {
     return findShortestPath(unit, destination.xCoord, destination.yCoord, map, false);
   }
   /** Alias for {@link #findShortestPath(XYCoord, Unit, int, int, GameMap, boolean) findShortestPath(XYCoord, Unit, int, int, GameMap, boolean=false)} **/
-  public static Path findShortestPath(Unit unit, int x, int y, GameMap map)
+  public static GamePath findShortestPath(Unit unit, int x, int y, GameMap map)
   {
     return findShortestPath(unit, x, y, map, false);
   }
   /** Alias for {@link #findShortestPath(XYCoord, Unit, int, int, GameMap, boolean) findShortestPath(XYCoord, Unit, int, int, GameMap, boolean=false)} **/
-  public static Path findShortestPath(XYCoord start, Unit unit, int x, int y, GameMap map)
+  public static GamePath findShortestPath(XYCoord start, Unit unit, int x, int y, GameMap map)
   {
     return findShortestPath(start, unit, x, y, map, false);
   }
   /** Alias for {@link #findShortestPath(XYCoord, Unit, int, int, GameMap, boolean) findShortestPath(XYCoord, Unit, int, int, GameMap, boolean=false)} **/
-  public static Path findShortestPath(XYCoord start, Unit unit, XYCoord destination, GameMap map)
+  public static GamePath findShortestPath(XYCoord start, Unit unit, XYCoord destination, GameMap map)
   {
     return findShortestPath(start, unit, destination.xCoord, destination.yCoord, map, false);
   }
@@ -245,7 +245,7 @@ public class Utils
    * Alias for {@link #findShortestPath(XYCoord, Unit, int, int, GameMap, boolean) findShortestPath(XYCoord, Unit, int, int, GameMap, boolean=false)}
    * @param theoretical If true, ignores other Units and move-power limitations.
    */
-  public static Path findShortestPath(XYCoord start, Unit unit, int x, int y, GameMap map, boolean theoretical)
+  public static GamePath findShortestPath(XYCoord start, Unit unit, int x, int y, GameMap map, boolean theoretical)
   {
     // findShortestPath() is given a particular endpoint already, so it assumes that it is valid to end up there.
     return findShortestPath(start, unit.getMoveFunctor(true, theoretical),
@@ -263,14 +263,14 @@ public class Utils
    * @param y Final Y coordinate
    * @param map The map to search over.
    */
-  public static Path findShortestPath(XYCoord start, FloodFillFunctor fff, int initialFillPower, int x, int y, GameMap map)
+  public static GamePath findShortestPath(XYCoord start, FloodFillFunctor fff, int initialFillPower, int x, int y, GameMap map)
   {
     if( null == start || null == fff || null == map || !map.isLocationValid(start.xCoord, start.yCoord) )
     {
       return null;
     }
 
-    Path aPath = new Path();
+    GamePath aPath = new GamePath();
     if( !map.isLocationValid(x, y) )
     {
       // Unit is not in a valid place. No path can be found.
@@ -590,7 +590,7 @@ public class Utils
     return locations;
   }
 
-  public static boolean pathCollides(GameMap map, Unit unit, Path path)
+  public static boolean pathCollides(GameMap map, Unit unit, GamePath path)
   {
     boolean result = false;
     boolean includeOccupiedSpaces = true; // Shouldn't matter, as we don't invoke canEnd()
@@ -618,7 +618,7 @@ public class Utils
    * @param eventQueue Will be given the new MoveEvent.
    * @return true if the move is created as specified, false if the path was shortened.
    */
-  public static boolean enqueueMoveEvent(MapMaster gameMap, Unit unit, Path movePath, GameEventQueue eventQueue)
+  public static boolean enqueueMoveEvent(MapMaster gameMap, Unit unit, GamePath movePath, GameEventQueue eventQueue)
   {
     boolean originalPathOK = true;
     if( Utils.pathCollides(gameMap, unit, movePath) )

--- a/src/Engine/Utils.java
+++ b/src/Engine/Utils.java
@@ -13,7 +13,7 @@ import CommandingOfficers.Commander;
 import Engine.GameEvents.GameEventQueue;
 import Engine.GameEvents.UnitDieEvent;
 import Terrain.GameMap;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.MapMaster;
 import Units.Unit;
 import Units.WeaponModel;
@@ -450,7 +450,7 @@ public class Utils
       // Add all vacant, <co>-owned industries to the list
       for( XYCoord xyc : co.ownedProperties )
       {
-        Location loc = map.getLocation(xyc);
+        MapLocation loc = map.getLocation(xyc);
         Unit resident = loc.getResident();
         // We only want industries we can act on, which means they need to be empty
         // TODO: maybe calculate whether the CO has enough money to buy something at this industry

--- a/src/Terrain/GameMap.java
+++ b/src/Terrain/GameMap.java
@@ -37,11 +37,11 @@ public abstract class GameMap implements Serializable, IEnvironsProvider
   /** Returns the Unit in the specified tile. */
   public abstract Unit getResident(int w, int h);
 
-  /** Returns the Location at the specified location, or null if that Location does not exist. */
-  public abstract Location getLocation(XYCoord location);
+  /** Returns the MapLocation at the specified location, or null if that MapLocation does not exist. */
+  public abstract MapLocation getLocation(XYCoord location);
 
-  /** Returns the Location at the specified location, or null if that Location does not exist. */
-  public abstract Location getLocation(int w, int h);
+  /** Returns the MapLocation at the specified location, or null if that MapLocation does not exist. */
+  public abstract MapLocation getLocation(int w, int h);
 
   public abstract void clearAllHighlights();
 
@@ -51,10 +51,10 @@ public abstract class GameMap implements Serializable, IEnvironsProvider
   /** Returns true if no unit is at the specified x and y coordinate, false else */
   public abstract boolean isLocationEmpty(int x, int y);
 
-  /** Returns true if no unit (excluding 'unit') is in the specified Location. */
+  /** Returns true if no unit (excluding 'unit') is in the specified MapLocation. */
   public abstract boolean isLocationEmpty(Unit unit, XYCoord coords);
 
-  /** Returns true if no unit (excluding 'unit') is in the specified Location. */
+  /** Returns true if no unit (excluding 'unit') is in the specified MapLocation. */
   public abstract boolean isLocationEmpty(Unit unit, int x, int y);
 
   /** Returns true if the location lies outside the GameMap. */

--- a/src/Terrain/GameMap.java
+++ b/src/Terrain/GameMap.java
@@ -2,7 +2,7 @@ package Terrain;
 
 import java.io.Serializable;
 
-import Engine.Path;
+import Engine.GamePath;
 import Engine.XYCoord;
 import Units.Unit;
 
@@ -70,7 +70,7 @@ public abstract class GameMap implements Serializable, IEnvironsProvider
   {}
 
   /** Reveals fog along the movement path, if applicable */
-  public void revealFog(Unit scout, Path movepath)
+  public void revealFog(Unit scout, GamePath movepath)
   {}
 
   /** Reveals a single tile of fog */

--- a/src/Terrain/MapFog.java
+++ b/src/Terrain/MapFog.java
@@ -9,7 +9,7 @@ import Engine.Utils;
 import Engine.XYCoord;
 import Units.Unit;
 
-public class MapWindow extends GameMap
+public class MapFog extends GameMap
 {
   private static final long serialVersionUID = 1L;
   MapMaster master;
@@ -18,7 +18,7 @@ public class MapWindow extends GameMap
   private Commander[][] lastOwnerSeen;
   private ArrayList<Unit> confirmedVisibles;
 
-  public MapWindow(MapMaster pMaster, Commander pViewer)
+  public MapFog(MapMaster pMaster, Commander pViewer)
   {
     super(pMaster.mapWidth, pMaster.mapHeight);
     master = pMaster;

--- a/src/Terrain/MapLocation.java
+++ b/src/Terrain/MapLocation.java
@@ -10,7 +10,7 @@ import Units.ITargetable;
 import Units.Unit;
 import Units.WeaponModel;
 
-public class Location implements Serializable, ITargetable
+public class MapLocation implements Serializable, ITargetable
 {
   private static final long serialVersionUID = 1L;
   private Environment environs = null;
@@ -67,7 +67,7 @@ public class Location implements Serializable, ITargetable
   }
 
   /**
-   * @return true if this Location has an ownable environment, false else.
+   * @return true if this MapLocation has an ownable environment, false else.
    */
   public boolean isCaptureable()
   {
@@ -90,7 +90,7 @@ public class Location implements Serializable, ITargetable
     return highlightSet;
   }
 
-  public Location(Environment environment, XYCoord coordinates)
+  public MapLocation(Environment environment, XYCoord coordinates)
   {
     environs = environment;
     owner = null;

--- a/src/Terrain/MapMaster.java
+++ b/src/Terrain/MapMaster.java
@@ -11,7 +11,7 @@ import Units.UnitModelScheme;
 public class MapMaster extends GameMap
 {
   private static final long serialVersionUID = 1L;
-  private Location[][] map;
+  private MapLocation[][] map;
   public CommandingOfficers.Commander[] commanders;
 
   private boolean initOK = false;
@@ -21,7 +21,7 @@ public class MapMaster extends GameMap
     super(mapInfo.getWidth(), mapInfo.getHeight());
     initOK = true;
     commanders = COs;
-    map = new Location[mapWidth][mapHeight];
+    map = new MapLocation[mapWidth][mapHeight];
 
     // Build the map locations based on the MapInfo data.
     for( int y = 0; y < mapHeight; ++y )
@@ -29,8 +29,8 @@ public class MapMaster extends GameMap
       for( int x = 0; x < mapWidth; ++x )
       {
         TerrainType terrain = mapInfo.terrain[x][y];
-        // Create this Location using the MapInfo terrain.
-        map[x][y] = new Location(Environment.getTile(terrain, Environment.Weathers.CLEAR), new XYCoord(x, y));
+        // Create this MapLocation using the MapInfo terrain.
+        map[x][y] = new MapLocation(Environment.getTile(terrain, Environment.Weathers.CLEAR), new XYCoord(x, y));
       }
     }
 
@@ -57,7 +57,7 @@ public class MapMaster extends GameMap
         XYCoord coord = mapInfo.COProperties[co][i];
         int x = coord.xCoord;
         int y = coord.yCoord;
-        Location location = map[x][y];
+        MapLocation location = map[x][y];
         if( location.isCaptureable() )
         {
           // Check if this location holds an HQ.
@@ -170,18 +170,18 @@ public class MapMaster extends GameMap
     return map[w][h].getResident();
   }
 
-  /** Returns the Location at the specified location, or null if that Location does not exist. */
+  /** Returns the MapLocation at the specified location, or null if that MapLocation does not exist. */
   @Override
-  public Location getLocation(XYCoord location)
+  public MapLocation getLocation(XYCoord location)
   {
     if (null != location)
       return getLocation(location.xCoord, location.yCoord);
     return null;
   }
 
-  /** Returns the Location at the specified location, or null if that Location does not exist. */
+  /** Returns the MapLocation at the specified location, or null if that MapLocation does not exist. */
   @Override
-  public Location getLocation(int w, int h)
+  public MapLocation getLocation(int w, int h)
   {
     if( !isLocationValid(w, h) )
     {
@@ -216,14 +216,14 @@ public class MapMaster extends GameMap
     return isLocationEmpty(null, x, y);
   }
 
-  /** Returns true if no unit (excluding 'unit') is in the specified Location. */
+  /** Returns true if no unit (excluding 'unit') is in the specified MapLocation. */
   @Override
   public boolean isLocationEmpty(Unit unit, XYCoord coords)
   {
     return isLocationEmpty(unit, coords.xCoord, coords.yCoord);
   }
 
-  /** Returns true if no unit (excluding 'unit') is in the specified Location. */
+  /** Returns true if no unit (excluding 'unit') is in the specified MapLocation. */
   @Override
   public boolean isLocationEmpty(Unit unit, int x, int y)
   {
@@ -247,7 +247,7 @@ public class MapMaster extends GameMap
     Unit resident = getLocation(x, y).getResident();
     if( resident != null && !force )
     {
-      System.out.println("Error! Attempting to add a unit to an occupied Location!");
+      System.out.println("Error! Attempting to add a unit to an occupied MapLocation!");
       return;
     }
 
@@ -280,13 +280,13 @@ public class MapMaster extends GameMap
       }
       else
       {
-        System.out.println("ERROR! Attempting to move unit to an occupied Location!");
+        System.out.println("ERROR! Attempting to move unit to an occupied MapLocation!");
         return;
       }
     }
 
     // Update the map
-    Location priorLoc = getLocation(unit.x, unit.y);
+    MapLocation priorLoc = getLocation(unit.x, unit.y);
     if( null != priorLoc && priorLoc.getResident() == unit )
     {
       priorLoc.setResident(null);

--- a/src/Terrain/MapPerspective.java
+++ b/src/Terrain/MapPerspective.java
@@ -9,7 +9,7 @@ import Engine.Utils;
 import Engine.XYCoord;
 import Units.Unit;
 
-public class MapFog extends GameMap
+public class MapPerspective extends GameMap
 {
   private static final long serialVersionUID = 1L;
   MapMaster master;
@@ -18,7 +18,7 @@ public class MapFog extends GameMap
   private Commander[][] lastOwnerSeen;
   private ArrayList<Unit> confirmedVisibles;
 
-  public MapFog(MapMaster pMaster, Commander pViewer)
+  public MapPerspective(MapMaster pMaster, Commander pViewer)
   {
     super(pMaster.mapWidth, pMaster.mapHeight);
     master = pMaster;

--- a/src/Terrain/MapWindow.java
+++ b/src/Terrain/MapWindow.java
@@ -3,8 +3,8 @@ package Terrain;
 import java.util.ArrayList;
 
 import CommandingOfficers.Commander;
-import Engine.Path;
-import Engine.Path.PathNode;
+import Engine.GamePath;
+import Engine.GamePath.PathNode;
 import Engine.Utils;
 import Engine.XYCoord;
 import Units.Unit;
@@ -234,7 +234,7 @@ public class MapWindow extends GameMap
   }
 
   @Override
-  public void revealFog(Unit scout, Path movepath)
+  public void revealFog(Unit scout, GamePath movepath)
   {
     if (null == viewer)
       return;

--- a/src/Terrain/MapWindow.java
+++ b/src/Terrain/MapWindow.java
@@ -84,26 +84,26 @@ public class MapWindow extends GameMap
     return getLocation(w, h).getResident();
   }
 
-  /** Returns the Location at the specified location, or null if that Location does not exist. */
+  /** Returns the MapLocation at the specified location, or null if that MapLocation does not exist. */
   @Override
-  public Location getLocation(XYCoord location)
+  public MapLocation getLocation(XYCoord location)
   {
     if (null != location)
       return getLocation(location.xCoord, location.yCoord);
     return null;
   }
 
-  /** Returns the Location at the specified location, or null if that Location does not exist. */
+  /** Returns the MapLocation at the specified location, or null if that MapLocation does not exist. */
   @Override
-  public Location getLocation(int x, int y)
+  public MapLocation getLocation(int x, int y)
   {
     XYCoord coord = new XYCoord(x, y);
-    Location masterLoc = master.getLocation(coord);
-    Location returnLoc = masterLoc;
+    MapLocation masterLoc = master.getLocation(coord);
+    MapLocation returnLoc = masterLoc;
     if( isLocationFogged(coord) || // If we can't see anything...
         (isLocationEmpty(coord) && !master.isLocationEmpty(coord)) ) // ...or what's there is hidden
     {
-      returnLoc = new Location(returnLoc.getEnvironment(), coord);
+      returnLoc = new MapLocation(returnLoc.getEnvironment(), coord);
       returnLoc.setHighlight(masterLoc.isHighlightSet());
       returnLoc.setOwner( lastOwnerSeen[x][y] );
     }
@@ -130,14 +130,14 @@ public class MapWindow extends GameMap
     return isLocationEmpty(null, x, y);
   }
 
-  /** Returns true if no unit (excluding 'unit') is in the specified Location. */
+  /** Returns true if no unit (excluding 'unit') is in the specified MapLocation. */
   @Override
   public boolean isLocationEmpty(Unit unit, XYCoord coords)
   {
     return isLocationEmpty(unit, coords.xCoord, coords.yCoord);
   }
 
-  /** Returns true if no unit (excluding 'unit') is in the specified Location. */
+  /** Returns true if no unit (excluding 'unit') is in the specified MapLocation. */
   @Override
   public boolean isLocationEmpty(Unit unit, int x, int y)
   {
@@ -204,7 +204,7 @@ public class MapWindow extends GameMap
         for( XYCoord xyc : co.ownedProperties )
         {
           revealFog(xyc, true); // Properties can see themselves and anything on them
-          Location loc = master.getLocation(xyc);
+          MapLocation loc = master.getLocation(xyc);
           for( XYCoord coord : Utils.findVisibleLocations(this, loc.getCoordinates(), Environment.PROPERTY_VISION_RANGE) )
           {
             revealFog(coord, false);
@@ -257,7 +257,7 @@ public class MapWindow extends GameMap
   
   public void revealFog(XYCoord coord, boolean piercing)
   {
-    Location loc = master.getLocation(coord);
+    MapLocation loc = master.getLocation(coord);
     isFogged[coord.xCoord][coord.yCoord] = false;
     lastOwnerSeen[coord.xCoord][coord.yCoord] = loc.getOwner();
     if (piercing && loc.getResident() != null)

--- a/src/Test/TestCapture.java
+++ b/src/Test/TestCapture.java
@@ -13,7 +13,7 @@ import Engine.GameEvents.GameEventQueue;
 import Engine.UnitActionLifecycles.BattleLifecycle;
 import Engine.UnitActionLifecycles.CaptureLifecycle;
 import Engine.UnitActionLifecycles.WaitLifecycle;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.MapLibrary;
 import Terrain.MapMaster;
 import Terrain.TerrainType;
@@ -57,7 +57,7 @@ public class TestCapture extends TestCase
     boolean testPassed = true;
 
     // Get a reference to a capturable property.
-    Location prop = testMap.getLocation(2, 2);
+    MapLocation prop = testMap.getLocation(2, 2);
 
     // Make sure this location is capturable.
     testPassed &= validate( prop.isCaptureable(), "    Unexpected terrain found! Test will be invalid." );
@@ -129,7 +129,7 @@ public class TestCapture extends TestCase
     boolean testPassed = true;
 
     // Get a reference to a capturable property.
-    Location prop = testMap.getLocation(2, 2);
+    MapLocation prop = testMap.getLocation(2, 2);
 
     // Make sure this location is capturable.
     testPassed &= validate( prop.isCaptureable(), "    Unexpected terrain found! Test will be invalid." );
@@ -173,7 +173,7 @@ public class TestCapture extends TestCase
     setupTest(); // Reset test parameters to ensure it's all set up hunky-dory.
 
     // We loaded Firing Range, so we expect an HQ for testCo2 at location (13, 1)
-    Terrain.Location hq = testMap.getLocation(13, 1);
+    Terrain.MapLocation hq = testMap.getLocation(13, 1);
     testPassed &= validate( hq.getOwner() == testCo2, "    HQ at (13, 1) is not owned by testCo2, but should be.");
     testPassed &= validate( hq.getEnvironment().terrainType == TerrainType.HEADQUARTERS, "    HQ for testCo2 is not where expected.");
 

--- a/src/Test/TestCommanderAve.java
+++ b/src/Test/TestCommanderAve.java
@@ -87,7 +87,7 @@ public class TestCommanderAve extends TestCase
     // Verify that after initializing the first time, Ave's properties are all snow-bound.
     for( XYCoord prop : Ave.ownedProperties )
     {
-      testPassed &= validate(testMap.isLocationValid(prop), "    Location is invalid!");
+      testPassed &= validate(testMap.isLocationValid(prop), "    MapLocation is invalid!");
       testPassed &= validate(testMap.getLocation(prop).getEnvironment().weatherType == Weathers.SNOW, "    Weather at " + prop + " is not snow!");
     }
 

--- a/src/Test/TestGameEvent.java
+++ b/src/Test/TestGameEvent.java
@@ -89,7 +89,7 @@ public class TestGameEvent extends TestCase
     boolean testPassed = true;
 
     // We loaded Firing Range, so we expect a city at location (2, 2)
-    Terrain.Location city = testMap.getLocation(2, 2);
+    Terrain.MapLocation city = testMap.getLocation(2, 2);
     testPassed &= validate(city.getEnvironment().terrainType == TerrainType.CITY, "    No city at (2, 2).");
     testPassed &= validate(city.getOwner() == null, "    City should not be owned by any CO yet.");
 
@@ -150,7 +150,7 @@ public class TestGameEvent extends TestCase
     XYCoord coords = new XYCoord(13, 8);
     CreateUnitEvent event = new CreateUnitEvent(testCo1, testCo1.getUnitModel(UnitModel.TROOP), coords);
 
-    testPassed &= validate(testMap.getLocation(coords).getResident() == null, "    Location is already occupied.");
+    testPassed &= validate(testMap.getLocation(coords).getResident() == null, "    MapLocation is already occupied.");
 
     event.performEvent(testMap);
 
@@ -196,7 +196,7 @@ public class TestGameEvent extends TestCase
 
     // Unload the mech; this should fail, since he is not on the transport.
     new UnloadLifecycle.UnloadEvent(apc, mech, 3, 3).performEvent(testMap);
-    testPassed &= validate(testMap.getLocation(3, 3).getResident() == null, "    Location (3, 3) should have no residents.");
+    testPassed &= validate(testMap.getLocation(3, 3).getResident() == null, "    MapLocation (3, 3) should have no residents.");
     testPassed &= validate(2 == mech.x && 3 == mech.y, "    Mech thinks he has moved, but should still be at (2, 3).");
     testPassed &= validate(apc.heldUnits.size() == 1, "    APC should still have one passenger.");
 
@@ -243,7 +243,7 @@ public class TestGameEvent extends TestCase
     new MoveEvent(mech, path).performEvent(testMap); // This should not execute. Water is bad for grunts.
     testPassed &= validate(7 == mech.x && 6 == mech.y, "    Mech does not think he is at (7, 6), but should.");
     testPassed &= validate(testMap.getLocation(7, 6).getResident() == mech, "    Mech is not still at (7, 6), but should be.");
-    testPassed &= validate(testMap.getLocation(7, 0).getResident() == null, "    Location (7, 0) should still be empty.");
+    testPassed &= validate(testMap.getLocation(7, 0).getResident() == null, "    MapLocation (7, 0) should still be empty.");
 
     path.addWaypoint(7, 5); // New endpoint to move apc over infantry.
     new MoveEvent(apc, path).performEvent(testMap); // This should not execute. Treads are bad for grunts.
@@ -414,12 +414,12 @@ public class TestGameEvent extends TestCase
     testPassed &= validate(testCo2.isDefeated == false, "    testCo2 started out in defeat, but he should not be.");
 
     // We loaded Firing Range, so we expect a city at location (2, 2)
-    Terrain.Location city = testMap.getLocation(10, 1);
+    Terrain.MapLocation city = testMap.getLocation(10, 1);
     // ... an HQ at location (13, 1)
-    Terrain.Location hq = testMap.getLocation(13, 1);
+    Terrain.MapLocation hq = testMap.getLocation(13, 1);
     // ... and two factories at (13, 2) and (12, 2).
-    Terrain.Location fac1 = testMap.getLocation(13, 2);
-    Terrain.Location fac2 = testMap.getLocation(12, 2);
+    Terrain.MapLocation fac1 = testMap.getLocation(13, 2);
+    Terrain.MapLocation fac2 = testMap.getLocation(12, 2);
 
     // Verify the map looks as we expect.
     testPassed &= validate(city.getEnvironment().terrainType == TerrainType.CITY, "    No city at (10, 1).");

--- a/src/Test/TestGameEvent.java
+++ b/src/Test/TestGameEvent.java
@@ -5,7 +5,7 @@ import CommandingOfficers.Patch;
 import Engine.GameAction;
 import Engine.GameInstance;
 import Engine.GameScenario;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.Utils;
 import Engine.XYCoord;
 import Engine.GameEvents.CommanderDefeatEvent;
@@ -224,7 +224,7 @@ public class TestGameEvent extends TestCase
     Unit mech = addUnit(testMap, testCo1, UnitModel.MECH, 2, 3);
     Unit apc = addUnit(testMap, testCo1, UnitModel.TRANSPORT, 3, 2);
 
-    Path path = new Path();
+    GamePath path = new GamePath();
     path.addWaypoint(3, 3); // we need two waypoints to not break compatibility with MoveEvent, since it assumes the first waypoint isn't used.
     path.addWaypoint(7, 5); // A suitable place to move (should be the middle of the road in Firing Range).
 

--- a/src/Test/TestTeleport.java
+++ b/src/Test/TestTeleport.java
@@ -8,6 +8,7 @@ import Engine.GameScenario;
 import Engine.GameEvents.CommanderDefeatEvent;
 import Engine.GameEvents.GameEvent;
 import Engine.GameEvents.GameEventListener;
+import Engine.GameEvents.GameEventQueue;
 import Engine.GameEvents.TeleportEvent;
 import Engine.XYCoord;
 import Terrain.MapLibrary;
@@ -113,7 +114,7 @@ public class TestTeleport extends TestCase
     return testPassed;
   }
 
-  private static class TestListener extends GameEventListener
+  private static class TestListener implements GameEventListener
   {
     private static final long serialVersionUID = 1L;
     public boolean death;
@@ -125,15 +126,17 @@ public class TestTeleport extends TestCase
     }
 
     @Override
-    public void receiveUnitDieEvent(Unit unit, XYCoord grave, Integer hpLost)
+    public GameEventQueue receiveUnitDieEvent(Unit unit, XYCoord grave, Integer hpLost)
     {
       death = true;
+      return null;
     }
     
     @Override
-    public void receiveCommanderDefeatEvent(CommanderDefeatEvent event)
+    public GameEventQueue receiveCommanderDefeatEvent(CommanderDefeatEvent event)
     {
       defeat = true;
+      return null;
     }
 
     public void reset() {death=false; defeat=false;}

--- a/src/Test/TestTransport.java
+++ b/src/Test/TestTransport.java
@@ -9,6 +9,7 @@ import Engine.GameScenario;
 import Engine.Utils;
 import Engine.XYCoord;
 import Engine.GameEvents.GameEventListener;
+import Engine.GameEvents.GameEventQueue;
 import Engine.UnitActionLifecycles.BattleLifecycle;
 import Engine.UnitActionLifecycles.DeleteLifecycle;
 import Engine.UnitActionLifecycles.LoadLifecycle;
@@ -170,14 +171,15 @@ public class TestTransport extends TestCase
     return testPassed;
   }
 
-  private class DeathCounter extends GameEventListener
+  private class DeathCounter implements GameEventListener
   {
     private static final long serialVersionUID = 1L;
     public int count = 0;
     @Override
-    public void receiveUnitDieEvent(Unit victim, XYCoord grave, Integer hpBeforeDeath)
+    public GameEventQueue receiveUnitDieEvent(Unit victim, XYCoord grave, Integer hpBeforeDeath)
     {
       count++;
+      return null;
     };
   }
 

--- a/src/Test/TestUnitMovement.java
+++ b/src/Test/TestUnitMovement.java
@@ -6,7 +6,7 @@ import CommandingOfficers.Strong;
 import Engine.GameAction;
 import Engine.GameInstance;
 import Engine.GameScenario;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.Utils;
 import Engine.XYCoord;
 import Engine.UnitActionLifecycles.WaitLifecycle;
@@ -52,7 +52,7 @@ public class TestUnitMovement extends TestCase
   {
     // Add a Unit and try to move it.
     Unit mover = addUnit(testMap, testCo1, UnitModel.TROOP, 4, 4);
-    Path mvPath = Utils.findShortestPath(mover, 4, 4, testMap);
+    GamePath mvPath = Utils.findShortestPath(mover, 4, 4, testMap);
 
     // A path from here to here should still have one path node.
     boolean testPassed = (mvPath.getPathLength() == 1);
@@ -68,7 +68,7 @@ public class TestUnitMovement extends TestCase
     GameAction nullPath = new WaitLifecycle.WaitAction(mover, null);
     testPassed &= validate(nullPath.getEvents(testMap).size() == 0, "    A WaitAction with a null path should have no events!");
     mover.initTurn(testMap);
-    GameAction emptyPath = new WaitLifecycle.WaitAction(mover, new Path());
+    GameAction emptyPath = new WaitLifecycle.WaitAction(mover, new GamePath());
     testPassed &= validate(emptyPath.getEvents(testMap).size() == 0,
         "    A WaitAction with an empty path should have no events!");
     mover.initTurn(testMap);
@@ -143,7 +143,7 @@ public class TestUnitMovement extends TestCase
     // We don't need any units, since whether fuel drain properly applies to units is handled by the other two tests.
 
     // A 7-space movement across nothing but grass.
-    Path grassPath = new Path();
+    GamePath grassPath = new GamePath();
     grassPath.addWaypoint(3, 7);
     grassPath.addWaypoint(4, 7);
     grassPath.addWaypoint(5, 7);
@@ -154,7 +154,7 @@ public class TestUnitMovement extends TestCase
     grassPath.addWaypoint(10, 7);
 
     // A 4-space movement across 1 road, 1 plain, 1 forest, and 1 city
-    Path multiPath = new Path();
+    GamePath multiPath = new GamePath();
     multiPath.addWaypoint(5, 6);
     multiPath.addWaypoint(4, 6);
     multiPath.addWaypoint(3, 6);

--- a/src/Test/TestVisionMechanics.java
+++ b/src/Test/TestVisionMechanics.java
@@ -6,7 +6,7 @@ import CommandingOfficers.Strong;
 import Engine.GameAction;
 import Engine.GameInstance;
 import Engine.GameScenario;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.Utils;
 import Engine.UnitActionLifecycles.BattleLifecycle;
 import Engine.UnitActionLifecycles.ResupplyLifecycle;
@@ -71,18 +71,18 @@ public class TestVisionMechanics extends TestCase
     testPassed &= validate(strong.myView.isLocationEmpty(6, 5),   "    We can magically see units in forests");
     testPassed &= validate(strong.myView.isLocationEmpty(7, 5),   "    We can magically see invisible tanks");
     
-    Path foolPath = Utils.findShortestPath(fool, 7, 8, strong.myView);
+    GamePath foolPath = Utils.findShortestPath(fool, 7, 8, strong.myView);
     GameAction resupplyBlind = new ResupplyLifecycle.ResupplyAction(fool, foolPath);
     testPassed &= validate(resupplyBlind.getEvents(testMap).size() == 1, "    Some fool was able to zoom straight through an invisible tank");
 
-    Path punchSit = Utils.findShortestPath(punch, punch.x, punch.y, strong.myView);
+    GamePath punchSit = Utils.findShortestPath(punch, punch.x, punch.y, strong.myView);
     GameAction missBait = new BattleLifecycle.BattleAction(strong.myView, punch, punchSit, 6, 5);
     testPassed &= validate(missBait.getEvents(testMap).size() == 0, "    You can shoot things hidden in forests.");
     GameAction missMeat = new BattleLifecycle.BattleAction(strong.myView, punch, punchSit, 7, 5);
     testPassed &= validate(missMeat.getEvents(testMap).size() == 0, "    You can shoot invisible things.");
 
     // Drive by the two hidden units
-    Path excursion = new Path();
+    GamePath excursion = new GamePath();
     excursion.addWaypoint(7, 3);
     excursion.addWaypoint(7, 4);
     excursion.addWaypoint(6, 4);

--- a/src/UI/Art/Animation/MoveAnimation.java
+++ b/src/UI/Art/Animation/MoveAnimation.java
@@ -2,7 +2,7 @@ package UI.Art.Animation;
 
 import java.awt.Graphics;
 
-import Engine.Path;
+import Engine.GamePath;
 import Engine.XYCoord;
 import UI.Art.SpriteArtist.UnitSpriteSet.AnimState;
 import Units.Unit;
@@ -11,10 +11,10 @@ public class MoveAnimation extends BaseUnitActionAnimation
 {
   private final long maxTime = 250;
 
-  private final Path path;
+  private final GamePath path;
   private final double tilesPerMs;
 
-  public MoveAnimation(int tileSize, Unit actor, Path path)
+  public MoveAnimation(int tileSize, Unit actor, GamePath path)
   {
     super(tileSize, actor, null);
     this.path = path;

--- a/src/UI/Art/SpriteArtist/MapArtist.java
+++ b/src/UI/Art/SpriteArtist/MapArtist.java
@@ -7,8 +7,8 @@ import java.util.ArrayList;
 
 import CommandingOfficers.Commander;
 import Engine.GameInstance;
-import Engine.Path;
-import Engine.Path.PathNode;
+import Engine.GamePath;
+import Engine.GamePath.PathNode;
 import Engine.Utils;
 import Engine.XYCoord;
 import Engine.GameEvents.GameEventListener;
@@ -94,7 +94,7 @@ public class MapArtist
     }
   }
 
-  public void drawMovePath(Graphics g, Path path)
+  public void drawMovePath(Graphics g, GamePath path)
   {
     Sprite moveLineSprites = SpriteLibrary.getMoveCursorLineSprite();
     Sprite moveArrowSprites = SpriteLibrary.getMoveCursorArrowSprite();

--- a/src/UI/Art/SpriteArtist/MapArtist.java
+++ b/src/UI/Art/SpriteArtist/MapArtist.java
@@ -12,6 +12,7 @@ import Engine.Path.PathNode;
 import Engine.Utils;
 import Engine.XYCoord;
 import Engine.GameEvents.GameEventListener;
+import Engine.GameEvents.GameEventQueue;
 import Engine.GameEvents.MapChangeEvent.EnvironmentAssignment;
 import Terrain.Environment.Weathers;
 import Terrain.GameMap;
@@ -195,7 +196,7 @@ public class MapArtist
     }
   }
 
-  private static class MapImageUpdater extends GameEventListener
+  private static class MapImageUpdater implements GameEventListener
   {
     private static final long serialVersionUID = 1L;
     MapArtist myArtist;
@@ -208,18 +209,20 @@ public class MapArtist
     public boolean shouldSerialize() { return false; }
 
     @Override
-    public void receiveTerrainChangeEvent(ArrayList<EnvironmentAssignment> terrainChanges)
+    public GameEventQueue receiveTerrainChangeEvent(ArrayList<EnvironmentAssignment> terrainChanges)
     {
       for( EnvironmentAssignment ea : terrainChanges )
       {
         if( null != ea.where ) myArtist.redrawBaseTile(ea.where); // Redraw each tile that changed.
       }
+      return null;
     }
 
     @Override
-    public void receiveWeatherChangeEvent(Weathers weather, int duration)
+    public GameEventQueue receiveWeatherChangeEvent(Weathers weather, int duration)
     {
       myArtist.buildMapImage(); // Redraw the whole map.
+      return null;
     }
   }
 

--- a/src/UI/Art/SpriteArtist/MapTileDetailsArtist.java
+++ b/src/UI/Art/SpriteArtist/MapTileDetailsArtist.java
@@ -4,10 +4,10 @@ import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
-import java.util.Map;
 
 import Engine.GameEvents.CommanderDefeatEvent;
 import Engine.GameEvents.GameEventListener;
+import Engine.GameEvents.GameEventQueue;
 import Engine.GameEvents.MapChangeEvent;
 import Engine.GameEvents.MoveEvent;
 import Engine.GameEvents.ResupplyEvent;
@@ -199,29 +199,28 @@ public class MapTileDetailsArtist
   }
 
   /** This class just listens for any event that could change what is under the cursor, which is pretty much all of them. */
-  private static class MtdaListener extends GameEventListener
+  private static class MtdaListener implements GameEventListener
   {
     private static final long serialVersionUID = 1L;
 
     @Override
     public boolean shouldSerialize() { return false; }
 
-    public void receiveBattleEvent(BattleSummary summary){MapTileDetailsArtist.resetOverlay();};
-    public void receiveDemolitionEvent(Unit actor, XYCoord tile){MapTileDetailsArtist.resetOverlay();};
-    public void receiveCreateUnitEvent(Unit unit){MapTileDetailsArtist.resetOverlay();};
-    public void receiveCaptureEvent(Unit unit, Location location){MapTileDetailsArtist.resetOverlay();};
-    public void receiveCommanderDefeatEvent(CommanderDefeatEvent event){MapTileDetailsArtist.resetOverlay();};
-    public void receiveLoadEvent(LoadLifecycle.LoadEvent event){MapTileDetailsArtist.resetOverlay();};
-    public void receiveMoveEvent(MoveEvent event){MapTileDetailsArtist.resetOverlay();};
-    public void receiveTeleportEvent(Unit teleporter, XYCoord from, XYCoord to){MapTileDetailsArtist.resetOverlay();};
-    public void receiveUnitJoinEvent(JoinLifecycle.JoinEvent event){MapTileDetailsArtist.resetOverlay();};
-    public void receiveResupplyEvent(ResupplyEvent event){MapTileDetailsArtist.resetOverlay();};
-    public void receiveUnitDieEvent(Unit victim, XYCoord grave, Integer hpBeforeDeath){MapTileDetailsArtist.resetOverlay();};
-    public void receiveUnloadEvent(UnloadLifecycle.UnloadEvent event){MapTileDetailsArtist.resetOverlay();};
-    public void receiveUnitTransformEvent(Unit unit, UnitModel oldType){MapTileDetailsArtist.resetOverlay();};
-    public void receiveTerrainChangeEvent(ArrayList<EnvironmentAssignment> terrainChanges){MapTileDetailsArtist.resetOverlay();};
-    public void receiveWeatherChangeEvent(Weathers weather, int duration){MapTileDetailsArtist.resetOverlay();};
-    public void receiveMapChangeEvent(MapChangeEvent event){MapTileDetailsArtist.resetOverlay();};
-    public void receiveMassDamageEvent(Map<Unit, Integer> lostHP){MapTileDetailsArtist.resetOverlay();};
+    public GameEventQueue receiveBattleEvent(BattleSummary summary){MapTileDetailsArtist.resetOverlay(); return null; };
+    public GameEventQueue receiveDemolitionEvent(Unit actor, XYCoord tile){MapTileDetailsArtist.resetOverlay(); return null; };
+    public GameEventQueue receiveCreateUnitEvent(Unit unit){MapTileDetailsArtist.resetOverlay(); return null; };
+    public GameEventQueue receiveCaptureEvent(Unit unit, Location location){MapTileDetailsArtist.resetOverlay(); return null; };
+    public GameEventQueue receiveCommanderDefeatEvent(CommanderDefeatEvent event){MapTileDetailsArtist.resetOverlay(); return null; };
+    public GameEventQueue receiveLoadEvent(LoadLifecycle.LoadEvent event){MapTileDetailsArtist.resetOverlay(); return null; };
+    public GameEventQueue receiveMoveEvent(MoveEvent event){MapTileDetailsArtist.resetOverlay(); return null; };
+    public GameEventQueue receiveTeleportEvent(Unit teleporter, XYCoord from, XYCoord to){MapTileDetailsArtist.resetOverlay(); return null; };
+    public GameEventQueue receiveUnitJoinEvent(JoinLifecycle.JoinEvent event){MapTileDetailsArtist.resetOverlay(); return null; };
+    public GameEventQueue receiveResupplyEvent(ResupplyEvent event){MapTileDetailsArtist.resetOverlay(); return null; };
+    public GameEventQueue receiveUnitDieEvent(Unit victim, XYCoord grave, Integer hpBeforeDeath){MapTileDetailsArtist.resetOverlay(); return null; };
+    public GameEventQueue receiveUnloadEvent(UnloadLifecycle.UnloadEvent event){MapTileDetailsArtist.resetOverlay(); return null; };
+    public GameEventQueue receiveUnitTransformEvent(Unit unit, UnitModel oldType){MapTileDetailsArtist.resetOverlay(); return null; };
+    public GameEventQueue receiveTerrainChangeEvent(ArrayList<EnvironmentAssignment> terrainChanges){MapTileDetailsArtist.resetOverlay(); return null; };
+    public GameEventQueue receiveWeatherChangeEvent(Weathers weather, int duration){MapTileDetailsArtist.resetOverlay(); return null; };
+    public GameEventQueue receiveMapChangeEvent(MapChangeEvent event){MapTileDetailsArtist.resetOverlay(); return null; };
   }
 }

--- a/src/UI/Art/SpriteArtist/MapTileDetailsArtist.java
+++ b/src/UI/Art/SpriteArtist/MapTileDetailsArtist.java
@@ -19,7 +19,7 @@ import Engine.GameInstance;
 import Engine.XYCoord;
 import Engine.Combat.BattleSummary;
 import Terrain.GameMap;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.TerrainType;
 import Terrain.Environment.Weathers;
 import Units.Unit;
@@ -87,7 +87,7 @@ public class MapTileDetailsArtist
     // Define useful quantities.
     int tileSize = SpriteLibrary.baseSpriteSize;
     int iconSize = SpriteLibrary.baseSpriteSize/2;
-    Location loc = map.getLocation(coord);
+    MapLocation loc = map.getLocation(coord);
     TerrainType terrain = loc.getEnvironment().terrainType;
     boolean isTerrainObject = TerrainSpriteSet.isTerrainObject(terrain);
     Unit unit = loc.getResident();
@@ -209,7 +209,7 @@ public class MapTileDetailsArtist
     public GameEventQueue receiveBattleEvent(BattleSummary summary){MapTileDetailsArtist.resetOverlay(); return null; };
     public GameEventQueue receiveDemolitionEvent(Unit actor, XYCoord tile){MapTileDetailsArtist.resetOverlay(); return null; };
     public GameEventQueue receiveCreateUnitEvent(Unit unit){MapTileDetailsArtist.resetOverlay(); return null; };
-    public GameEventQueue receiveCaptureEvent(Unit unit, Location location){MapTileDetailsArtist.resetOverlay(); return null; };
+    public GameEventQueue receiveCaptureEvent(Unit unit, MapLocation location){MapTileDetailsArtist.resetOverlay(); return null; };
     public GameEventQueue receiveCommanderDefeatEvent(CommanderDefeatEvent event){MapTileDetailsArtist.resetOverlay(); return null; };
     public GameEventQueue receiveLoadEvent(LoadLifecycle.LoadEvent event){MapTileDetailsArtist.resetOverlay(); return null; };
     public GameEventQueue receiveMoveEvent(MoveEvent event){MapTileDetailsArtist.resetOverlay(); return null; };

--- a/src/UI/Art/SpriteArtist/OverlayArtist.java
+++ b/src/UI/Art/SpriteArtist/OverlayArtist.java
@@ -136,7 +136,7 @@ public class OverlayArtist
 
         if( gameMap.isLocationValid(w, h) )
         {
-          Terrain.Location locus = gameMap.getLocation(w, h);
+          Terrain.MapLocation locus = gameMap.getLocation(w, h);
           if( locus.isHighlightSet() )
           {
             og.setColor(HIGHLIGHT_COLOR);

--- a/src/UI/Art/SpriteArtist/SpriteLibrary.java
+++ b/src/UI/Art/SpriteArtist/SpriteLibrary.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import javax.imageio.ImageIO;
 
 import CommandingOfficers.Commander;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.TerrainType;
 import UI.UIUtils;
 import UI.UIUtils.COSpriteSpec;
@@ -122,7 +122,7 @@ public class SpriteLibrary
    * Retrieve (loading if needed) the sprites associated with the terrain type at the specified location.
    * This function returns the owner-appropriate version of the tile for ownable terrain types.
    */
-  public static TerrainSpriteSet getTerrainSpriteSet(Location loc)
+  public static TerrainSpriteSet getTerrainSpriteSet(MapLocation loc)
   {
     SpriteSetKey spriteKey = SpriteSetKey.instance(loc.getEnvironment().terrainType, COSpriteSpec.instance(loc.getOwner()));
     if( !spriteSetMap.containsKey(spriteKey) )

--- a/src/UI/Art/SpriteArtist/SpriteMapView.java
+++ b/src/UI/Art/SpriteArtist/SpriteMapView.java
@@ -19,7 +19,7 @@ import Engine.Combat.StrikeParams;
 import Engine.GameEvents.GameEvent;
 import Engine.GameEvents.GameEventQueue;
 import Terrain.GameMap;
-import Terrain.MapWindow;
+import Terrain.MapFog;
 import UI.GameOverlay;
 import UI.MapView;
 import UI.SlidingValue;
@@ -199,7 +199,7 @@ public class SpriteMapView extends MapView
    */
   private BufferedImage renderMap()
   {
-    MapWindow gameMap = getDrawableMap(myGame);
+    MapFog gameMap = getDrawableMap(myGame);
     
     // We draw in three stages. First, we draw the map/units onto a canvas which is the size
     // of the entire map; then we copy the visible section of that canvas onto a screen-sized

--- a/src/UI/Art/SpriteArtist/SpriteMapView.java
+++ b/src/UI/Art/SpriteArtist/SpriteMapView.java
@@ -19,7 +19,7 @@ import Engine.Combat.StrikeParams;
 import Engine.GameEvents.GameEvent;
 import Engine.GameEvents.GameEventQueue;
 import Terrain.GameMap;
-import Terrain.MapFog;
+import Terrain.MapPerspective;
 import UI.GameOverlay;
 import UI.MapView;
 import UI.SlidingValue;
@@ -199,7 +199,7 @@ public class SpriteMapView extends MapView
    */
   private BufferedImage renderMap()
   {
-    MapFog gameMap = getDrawableMap(myGame);
+    MapPerspective gameMap = getDrawableMap(myGame);
     
     // We draw in three stages. First, we draw the map/units onto a canvas which is the size
     // of the entire map; then we copy the visible section of that canvas onto a screen-sized

--- a/src/UI/Art/SpriteArtist/SpriteMapView.java
+++ b/src/UI/Art/SpriteArtist/SpriteMapView.java
@@ -10,7 +10,7 @@ import java.util.Queue;
 
 import CommandingOfficers.Commander;
 import Engine.GameInstance;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.Utils;
 import Engine.XYCoord;
 import Engine.Combat.BattleSummary;
@@ -235,7 +235,7 @@ public class SpriteMapView extends MapView
       currentAnimation = contemplationAnim.update(drawMultiplier, currentActor, actorCoord);
       notifyOnAnimEnd = false;
     }
-    Path currentPath = mapController.getContemplatedMove();
+    GamePath currentPath = mapController.getContemplatedMove();
     boolean isTargeting = mapController.isTargeting();
 
     // Start actually drawing things
@@ -423,7 +423,7 @@ public class SpriteMapView extends MapView
   }
 
   @Override // from MapView
-  public GameAnimation buildMoveAnimation(Unit unit, Path movePath)
+  public GameAnimation buildMoveAnimation(Unit unit, GamePath movePath)
   {
     return new MoveAnimation(SpriteLibrary.baseSpriteSize, unit, movePath);
   }

--- a/src/UI/COStateInfo.java
+++ b/src/UI/COStateInfo.java
@@ -2,7 +2,7 @@ package UI;
 
 import CommandingOfficers.Commander;
 import Terrain.GameMap;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Units.Unit;
 
 /** Convenience class to collate and format visible game state info for a given CO */
@@ -27,7 +27,7 @@ public class COStateInfo // TODO: Consider making this class parse data for all 
     {
       for( int h = 0; h < map.mapHeight; ++h )
       {
-        Location loc = map.getLocation(w, h);
+        MapLocation loc = map.getLocation(w, h);
         if( loc.isProfitable() && loc.getOwner() == viewed )
         {
           income += viewed.gameRules.incomePerCity + viewed.incomeAdjustment;

--- a/src/UI/MapView.java
+++ b/src/UI/MapView.java
@@ -13,7 +13,7 @@ import Engine.Combat.StrikeParams;
 import Engine.GameEvents.CommanderDefeatEvent;
 import Engine.GameEvents.GameEventQueue;
 import Engine.GameEvents.TeleportEvent;
-import Terrain.MapWindow;
+import Terrain.MapFog;
 import UI.Art.Animation.GameAnimation;
 import Units.Unit;
 
@@ -23,7 +23,7 @@ public abstract class MapView implements IView
 
   protected MapController mapController = null;
   
-  protected MapWindow foggedMap;
+  protected MapFog foggedMap;
 
   public void setController(MapController controller)
   {
@@ -118,7 +118,7 @@ public abstract class MapView implements IView
     return null;
   }
 
-  protected MapWindow getDrawableMap(GameInstance myGame)
+  protected MapFog getDrawableMap(GameInstance myGame)
   {
     // Here are the fog-drawing rules. If there are:
     //   zero humans - spectating - draw everything the current player sees.
@@ -126,7 +126,7 @@ public abstract class MapView implements IView
     //   2+ humans - player vs player - draw what the current player sees, IFF the player is human.
 
     // Humans need to see what they can see.
-    MapWindow gameMap = myGame.activeCO.myView;
+    MapFog gameMap = myGame.activeCO.myView;
     if( myGame.activeCO.isAI() ) // If it's not a human, figure out what to show.
     {
       int numHumans = countHumanPlayers(myGame);
@@ -140,7 +140,7 @@ public abstract class MapView implements IView
         // Hide everything during the AI's turn so the playing field is level.
         if( null == foggedMap )
         {
-          foggedMap = new MapWindow(myGame.gameMap, null);
+          foggedMap = new MapFog(myGame.gameMap, null);
           foggedMap.resetFog();
         }
         gameMap = foggedMap;
@@ -170,9 +170,9 @@ public abstract class MapView implements IView
    * Returns the map owned by the first human Commander found.
    * Intended to be used when there is only one human player.
    */
-  protected MapWindow getHumanPlayerMap(GameInstance myGame)
+  protected MapFog getHumanPlayerMap(GameInstance myGame)
   {
-    MapWindow map = null;
+    MapFog map = null;
 
     for( Commander co : myGame.commanders )
     {

--- a/src/UI/MapView.java
+++ b/src/UI/MapView.java
@@ -13,7 +13,7 @@ import Engine.Combat.StrikeParams;
 import Engine.GameEvents.CommanderDefeatEvent;
 import Engine.GameEvents.GameEventQueue;
 import Engine.GameEvents.TeleportEvent;
-import Terrain.MapFog;
+import Terrain.MapPerspective;
 import UI.Art.Animation.GameAnimation;
 import Units.Unit;
 
@@ -23,7 +23,7 @@ public abstract class MapView implements IView
 
   protected MapController mapController = null;
   
-  protected MapFog foggedMap;
+  protected MapPerspective foggedMap;
 
   public void setController(MapController controller)
   {
@@ -118,7 +118,7 @@ public abstract class MapView implements IView
     return null;
   }
 
-  protected MapFog getDrawableMap(GameInstance myGame)
+  protected MapPerspective getDrawableMap(GameInstance myGame)
   {
     // Here are the fog-drawing rules. If there are:
     //   zero humans - spectating - draw everything the current player sees.
@@ -126,7 +126,7 @@ public abstract class MapView implements IView
     //   2+ humans - player vs player - draw what the current player sees, IFF the player is human.
 
     // Humans need to see what they can see.
-    MapFog gameMap = myGame.activeCO.myView;
+    MapPerspective gameMap = myGame.activeCO.myView;
     if( myGame.activeCO.isAI() ) // If it's not a human, figure out what to show.
     {
       int numHumans = countHumanPlayers(myGame);
@@ -140,7 +140,7 @@ public abstract class MapView implements IView
         // Hide everything during the AI's turn so the playing field is level.
         if( null == foggedMap )
         {
-          foggedMap = new MapFog(myGame.gameMap, null);
+          foggedMap = new MapPerspective(myGame.gameMap, null);
           foggedMap.resetFog();
         }
         gameMap = foggedMap;
@@ -170,9 +170,9 @@ public abstract class MapView implements IView
    * Returns the map owned by the first human Commander found.
    * Intended to be used when there is only one human player.
    */
-  protected MapFog getHumanPlayerMap(GameInstance myGame)
+  protected MapPerspective getHumanPlayerMap(GameInstance myGame)
   {
-    MapFog map = null;
+    MapPerspective map = null;
 
     for( Commander co : myGame.commanders )
     {

--- a/src/UI/MapView.java
+++ b/src/UI/MapView.java
@@ -6,7 +6,7 @@ import CommandingOfficers.Commander;
 import Engine.GameInstance;
 import Engine.IView;
 import Engine.MapController;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.XYCoord;
 import Engine.Combat.BattleSummary;
 import Engine.Combat.StrikeParams;
@@ -97,7 +97,7 @@ public abstract class MapView implements IView
   {
     return null;
   }
-  public GameAnimation buildMoveAnimation( Unit unit, Path movePath )
+  public GameAnimation buildMoveAnimation( Unit unit, GamePath movePath )
   {
     return null;
   }

--- a/src/Units/Unit.java
+++ b/src/Units/Unit.java
@@ -11,7 +11,7 @@ import Engine.UnitActionFactory;
 import Engine.XYCoord;
 import Engine.GameEvents.GameEventQueue;
 import Terrain.GameMap;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.MapMaster;
 
 public class Unit implements Serializable
@@ -25,7 +25,7 @@ public class Unit implements Serializable
   public int fuel;
   public int materials;
   private int captureProgress;
-  private Location captureTarget;
+  private MapLocation captureTarget;
   public Commander CO;
   public boolean isTurnOver;
   public boolean isStunned;
@@ -64,7 +64,7 @@ public class Unit implements Serializable
     // Make a queue to return any init events.
     GameEventQueue events = new GameEventQueue();
 
-    Location locus = map.getLocation(x, y);
+    MapLocation locus = map.getLocation(x, y);
 
     // Only perform turn initialization for the unit if it is on the map.
     //   Units that are e.g. in a transport don't burn fuel, etc.
@@ -264,7 +264,7 @@ public class Unit implements Serializable
     return getHP() - before;
   }
 
-  public boolean capture(Location target)
+  public boolean capture(MapLocation target)
   {
     boolean success = false;
 

--- a/src/Units/Unit.java
+++ b/src/Units/Unit.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import CommandingOfficers.Commander;
 import Engine.FloodFillFunctor;
 import Engine.GameActionSet;
-import Engine.Path;
+import Engine.GamePath;
 import Engine.UnitActionFactory;
 import Engine.XYCoord;
 import Engine.GameEvents.GameEventQueue;
@@ -306,11 +306,11 @@ public class Unit implements Serializable
   }
 
   /** Compiles and returns a list of all actions this unit could perform on map after moving along movePath. */
-  public ArrayList<GameActionSet> getPossibleActions(GameMap map, Path movePath)
+  public ArrayList<GameActionSet> getPossibleActions(GameMap map, GamePath movePath)
   {
     return getPossibleActions(map, movePath, false);
   }
-  public ArrayList<GameActionSet> getPossibleActions(GameMap map, Path movePath, boolean ignoreResident)
+  public ArrayList<GameActionSet> getPossibleActions(GameMap map, GamePath movePath, boolean ignoreResident)
   {
     ArrayList<GameActionSet> actionSet = new ArrayList<GameActionSet>();
     for( UnitActionFactory at : model.possibleActions )

--- a/src/Units/UnitModel.java
+++ b/src/Units/UnitModel.java
@@ -13,7 +13,7 @@ import Engine.GameEvents.GameEventQueue;
 import Engine.GameEvents.HealUnitEvent;
 import Engine.GameEvents.ResupplyEvent;
 import Engine.GameEvents.UnitDieEvent;
-import Terrain.Location;
+import Terrain.MapLocation;
 import Terrain.MapMaster;
 import Terrain.TerrainType;
 import Units.MoveTypes.MoveType;
@@ -189,7 +189,7 @@ public abstract class UnitModel implements Serializable, ITargetable
     return COdef;
   }
 
-  public boolean canRepairOn(Location locus)
+  public boolean canRepairOn(MapLocation locus)
   {
     return healableHabs.contains(locus.getEnvironment().terrainType);
   }
@@ -204,7 +204,7 @@ public abstract class UnitModel implements Serializable, ITargetable
     GameEventQueue queue = new GameEventQueue();
 
     XYCoord xyc = new XYCoord(self.x, self.y);
-    Location loc = map.getLocation(xyc);
+    MapLocation loc = map.getLocation(xyc);
 
     // No actions for units in transports. Should also be checked in Unit.
     if( null == loc ) return queue;


### PR DESCRIPTION
Am I missing anything?

I did originally want event listeners to *only* affect game state by pushing out events, but I think I've changed on that.
Practically speaking, if we want to use a series of events that includes "return events", we have a very simple way of doing that: just don't apply any return events. The logic will be the same in both cases.
No operations will be duplicated or missed, since the direct changes the listeners do will be done independently by their listeners in the current game instances.
Sound reasonable?