### PR TITLE
Optimize

### DIFF
--- a/src/UI/Art/SpriteArtist/SpriteLibrary.java
+++ b/src/UI/Art/SpriteArtist/SpriteLibrary.java
@@ -681,10 +681,7 @@ public class SpriteLibrary
    */
   public static BufferedImage createTransparentSprite(int w, int h)
   {
-    BufferedImage bi = createDefaultBlankSprite(w, h);
-    Sprite spr = new Sprite(bi);
-    spr.colorize(Color.BLACK, new Color(0, 0, 0, 0));
-    return bi;
+    return new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
   }
 
   /**

--- a/src/UI/Art/SpriteArtist/SpriteLibrary.java
+++ b/src/UI/Art/SpriteArtist/SpriteLibrary.java
@@ -6,7 +6,6 @@ import java.awt.Graphics;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -247,7 +246,7 @@ public class SpriteLibrary
   {
     public final TerrainType terrainKey;
     public final COSpriteSpec commanderKey;
-    private static ArrayList<SpriteSetKey> instances = new ArrayList<SpriteSetKey>();
+    private static HashMap<Integer, SpriteSetKey> instances = new HashMap<>();
 
     private SpriteSetKey(TerrainType terrain, COSpriteSpec spec)
     {
@@ -257,22 +256,28 @@ public class SpriteLibrary
 
     public static SpriteSetKey instance(TerrainType terrain, COSpriteSpec spec)
     {
-      SpriteSetKey key = null;
-      for( int i = 0; i < instances.size(); ++i )
-      {
-        if( instances.get(i).terrainKey == terrain &&
-            (COSpriteSpec.support(instances.get(i).commanderKey, spec)) )
-        {
-          key = instances.get(i);
-          break;
-        }
-      }
+      int hash = myHash(terrain, spec);
+      SpriteSetKey key = instances.getOrDefault(hash, null);
       if( key == null )
       {
         key = new SpriteSetKey(terrain, spec);
-        instances.add(key);
+        instances.put(hash, key);
       }
       return key;
+    }
+
+    public static int myHash(TerrainType terrain, COSpriteSpec spec)
+    {
+      final int prime = 160091;
+      int result = 1;
+      result = prime * result + terrain.hashCode();
+      result = prime * result;
+      if(null != spec)
+        result += spec.faction.name.hashCode();
+      result = prime * result;
+      if(null != spec)
+        result += spec.color.hashCode();
+      return result;
     }
   }
 
@@ -284,7 +289,7 @@ public class SpriteLibrary
   {
     public final String unitTypeKey;
     public final COSpriteSpec spriteSpec;
-    private static ArrayList<UnitSpriteSetKey> instances = new ArrayList<UnitSpriteSetKey>();
+    private static HashMap<Integer, UnitSpriteSetKey> instances = new HashMap<>();
 
     private UnitSpriteSetKey(String unitType, Faction faction, Color color)
     {
@@ -294,22 +299,25 @@ public class SpriteLibrary
 
     public static UnitSpriteSetKey instance(String unitType, Faction faction, Color color)
     {
-      UnitSpriteSetKey key = null;
       String stdType = UnitModel.standardizeID(unitType);
-      for( int i = 0; i < instances.size(); ++i )
-      {
-        if( instances.get(i).unitTypeKey.equals(stdType) && instances.get(i).spriteSpec.supports(faction, color) )
-        {
-          key = instances.get(i);
-          break;
-        }
-      }
+      int hash = myHash(stdType, faction, color);
+      UnitSpriteSetKey key = instances.getOrDefault(hash, null);
       if( key == null )
       {
         key = new UnitSpriteSetKey(stdType, faction, color);
-        instances.add(key);
+        instances.put(hash, key);
       }
       return key;
+    }
+
+    public static int myHash(String unitTypeKey, Faction faction, Color color)
+    {
+      final int prime = 160091;
+      int result = 1;
+      result = prime * result + unitTypeKey.hashCode();
+      result = prime * result + faction.name.hashCode();
+      result = prime * result + color.hashCode();
+      return result;
     }
   }
 

--- a/src/UI/UIUtils.java
+++ b/src/UI/UIUtils.java
@@ -259,23 +259,6 @@ public class UIUtils
         spec = new COSpriteSpec(co.faction, co.myColor);
       return spec;
     }
-
-    public static boolean support(COSpriteSpec me, COSpriteSpec you)
-    {
-      // If we're the same, yay
-      if( me == you )
-        return true;
-      // If we're not the same and one of us is null, boo
-      if( null == me || null == you )
-        return false;
-
-      return me.supports(you.faction, you.color);
-    }
-
-    public boolean supports(Faction pFaction, Color pColor)
-    {
-      return faction.name.contentEquals(pFaction.name) && color.equals(pColor);
-    }
   }
 
   private static class TeamColorSpec implements Comparable<TeamColorSpec>


### PR DESCRIPTION
Somebody complained we were eating 20% of his CPU just sitting at the map, so I took a quick gander.
`createTransparentSprite()` went from ~95% of CPU time to negligible.
`UnitArtist.drawUnit()` went from ~30% of CPU time to ~10%
I think the `Terrain` sprite set change also improved CPU time a little, but I deleted my results and am too lazy to reproduce them. I mostly made the change for consistency with the other change in the same commit.

The overall change took CPU usage on my rig from 3-4% to 1-2%.