### PR TITLE
DoR Pathing Fixes

### DIFF
--- a/src/Engine/GameInput/SelectMoveLocation.java
+++ b/src/Engine/GameInput/SelectMoveLocation.java
@@ -109,7 +109,7 @@ class SelectMoveLocation extends GameInputState<XYCoord>
     Unit actor = myStateData.unitActor;
     XYCoord coord = myStateData.unitCoord;
     boolean canEndOnOccupied = true;
-    if( !Utils.isPathValid(actor, myStateData.path, myStateData.gameMap, canEndOnOccupied) )
+    if( !myStateData.path.getWaypoint(0).GetCoordinates().equals(coord) || !Utils.isPathValid(actor, myStateData.path, myStateData.gameMap, canEndOnOccupied) )
     {
       // The currently-built path is invalid. Try to generate a new one (may still return null).
       myStateData.path = Utils.findShortestPath(coord, actor, end, myStateData.gameMap);

--- a/src/Engine/GamePath.java
+++ b/src/Engine/GamePath.java
@@ -65,7 +65,7 @@ public class GamePath
     {
       XYCoord from = waypoints.get(i-1).GetCoordinates();
       XYCoord to   = waypoints.get( i ).GetCoordinates();
-      cost += fff.getTransitionCost(map, from, to);
+      cost += fff.getTransitionCost(map, from, to, co.army, true);
     }
     return cost * unit.fuelBurnPerTile;
   }

--- a/src/Engine/Utils.java
+++ b/src/Engine/Utils.java
@@ -177,9 +177,9 @@ public class Utils
 
   public static boolean isPathValid(Unit unit, GamePath path, GameMap map, boolean includeOccupiedSpaces)
   {
-    return isPathValid(new XYCoord(unit), unit, unit.CO.army, unit.getMoveFunctor(), Math.min(unit.getMovePower(map), unit.fuel), path, map, includeOccupiedSpaces);
+    return isPathValid(unit, unit.CO.army, unit.getMoveFunctor(), Math.min(unit.getMovePower(map), unit.fuel), path, map, includeOccupiedSpaces);
   }
-  public static boolean isPathValid(XYCoord start, Unit mover, Army team, MoveType fff, int initialFillPower, GamePath path, GameMap map, boolean includeOccupiedSpaces)
+  public static boolean isPathValid(Unit mover, Army team, MoveType fff, int initialFillPower, GamePath path, GameMap map, boolean includeOccupiedSpaces)
   {
     if( (null == path) || (null == fff) )
     {
@@ -187,7 +187,7 @@ public class Utils
     }
 
     // Make sure the first waypoint is under the Unit.
-    if( path.getPathLength() <= 0 || !path.getWaypoint(0).GetCoordinates().equals(start) )
+    if( path.getPathLength() <= 0 )
     {
       return false;
     }

--- a/src/Engine/Utils.java
+++ b/src/Engine/Utils.java
@@ -186,7 +186,7 @@ public class Utils
       return false;
     }
 
-    // Make sure the first waypoint is under the Unit.
+    // Make sure the path has at least the starting position.
     if( path.getPathLength() <= 0 )
     {
       return false;

--- a/src/Units/MoveTypes/MoveType.java
+++ b/src/Units/MoveTypes/MoveType.java
@@ -70,10 +70,6 @@ public class MoveType implements Serializable
     return cost.intValue();
   }
 
-  public int getTransitionCost(GameMap map, XYCoord from, XYCoord to)
-  {
-    return getTransitionCost(map, from, to, null, true);
-  }
   public int getTransitionCost(GameMap map, XYCoord from, XYCoord to,
                                Army team, boolean canTravelThroughEnemies)
   {


### PR DESCRIPTION
Found some weirdness in a HF test game.

Launched planes couldn't actually pick actions in the UI, since carried units are at (-1,-1).
`isPathValid()` is only used by `SelectMoveLocation`, and "path valid" doesn't scream "unit is at start of path", to me... so I figured just moving the check to the code that wants it was a sensible plan.

Since `GamePath` wasn't telling the `MoveType` which team the unit was on, the BShip/Carrier-movetype was assuming it wasn't allowed in the port, and thus returned a fuel cost of 99.
This wasn't technically a big deal (it won't sink since it's at port), but it would prevent the BShip from shooting.