### PR TITLE
Kaiju Wars unit tweaks

### DIFF
--- a/src/Units/KaijuActions.java
+++ b/src/Units/KaijuActions.java
@@ -182,7 +182,7 @@ public class KaijuActions
 
           if( canCounter && stomperType.hasRamSkill
               // Ram activates automatically, at range 1 vs valid targets
-              && 1 == destCoord.getDistance(kaijuState.unit) && !victimType.resistsKaiju )
+              && 1 == destCoord.getDistance(kaijuState.unit) && victimType.isLandUnit() && !victimType.resistsKaiju )
           {
             // Apply Ram - you lose its bonus move, but kill the target for free
             canCounter = false;

--- a/src/Units/KaijuWarsUnits.java
+++ b/src/Units/KaijuWarsUnits.java
@@ -60,9 +60,6 @@ public class KaijuWarsUnits extends UnitModelScheme
     factoryModels.add(Artillery());
     factoryModels.add(Maser());
     factoryModels.add(LigerPanther());
-    KaijuWarsUnitModel z2Hurt = SuperZ2Hurt();
-    factoryModels.add(SuperZ2(z2Hurt));
-    extras.add(z2Hurt);
     factoryModels.add(OGRPlatform());
 
     // Inscribe those war machines obtainable from an Airport.
@@ -78,6 +75,9 @@ public class KaijuWarsUnits extends UnitModelScheme
       carrier.baseActions.add(1, new UnitProduceLifecycle.UnitProduceFactory(airportModels.get(i)));
 
     airportModels.add(BigBoy());
+    KaijuWarsUnitModel z2Hurt = SuperZ2Hurt();
+    airportModels.add(SuperZ2(z2Hurt));
+    extras.add(z2Hurt);
     KaijuWarsUnitModel gunBot = GuncrossRobot();
     airportModels.add(GuncrossWing(gunBot));
     airportModels.add(Kaputnik());
@@ -278,22 +278,6 @@ public class KaijuWarsUnits extends UnitModelScheme
       super();
       setMoveCost(TerrainType.MOUNTAIN, 2);
       setMoveCost(Weathers.RAIN, TerrainType.MOUNTAIN, 3);
-    }
-  }
-  public static class Hovercraft extends FootMech
-  {
-    private static final long serialVersionUID = 1L;
-
-    public Hovercraft()
-    {
-      super();
-      moveCosts.get(Weathers.CLEAR).setAllSeaCosts(1);
-      moveCosts.get(Weathers.RAIN).setAllSeaCosts(1);
-      moveCosts.get(Weathers.SNOW).setAllSeaCosts(1);
-      moveCosts.get(Weathers.SANDSTORM).setAllSeaCosts(1);
-
-      setMoveCost(TerrainType.REEF, 2);
-      setMoveCost(Weathers.SNOW, TerrainType.SEA, 2);
     }
   }
 
@@ -636,12 +620,12 @@ public class KaijuWarsUnits extends UnitModelScheme
   public KaijuWarsUnitModel SuperZ2(UnitModel rezTo)
   {
     var b = baseBuilder();
-    b.role(UnitModel.ASSAULT | UnitModel.SURFACE_TO_AIR | UnitModel.TANK | UnitModel.LAND);
+    b.role(UnitModel.ASSAULT | UnitModel.AIR_TO_SURFACE | UnitModel.AIR_TO_AIR | UnitModel.TANK | UnitModel.HOVER | UnitModel.AIR_LOW);
 
     b.baseMovePower(3);
     b.costBase(PREP_COST * 4);
 
-    b.baseMoveType(new Hovercraft());
+    b.baseMoveType(new Flight());
     b.baseActions(new ArrayList<>(Arrays.asList(UnitActionFactory.COMBAT_VEHICLE_ACTIONS)));
     WeaponModel[] weapons = { new KaijuWarsWeapons.SuperZ2() };
     b.weapons(new ArrayList<>(Arrays.asList(weapons)));

--- a/src/Units/KaijuWarsWeapons.java
+++ b/src/Units/KaijuWarsWeapons.java
@@ -373,19 +373,17 @@ public class KaijuWarsWeapons
     @Override
     public void modifyMovePower(UnitContext uc)
     {
-      if( uc.map == null )
-        return;
-      if( !uc.map.isLocationValid(uc.coord) )
+      if( uc.env == null )
         return;
       if( uc.model.isAirUnit() )
       {
-        TerrainType tt = uc.map.getEnvironment(uc.coord).terrainType;
+        TerrainType tt = uc.env.terrainType;
         if( tt.healsAir() )
           uc.movePower += 3;
       }
       if( uc.model.isLandUnit() )
       {
-        TerrainType tt = uc.map.getEnvironment(uc.coord).terrainType;
+        TerrainType tt = uc.env.terrainType;
         if( TerrainType.BRIDGE == tt || TerrainType.ROAD == tt )
           uc.movePower += 2;
       }

--- a/src/Units/KaijuWarsWeapons.java
+++ b/src/Units/KaijuWarsWeapons.java
@@ -369,7 +369,7 @@ public class KaijuWarsWeapons
         params.baseDamage = getDamage(attack, attackBoost, counterPower);
     }
 
-    // Throwing the air-airport move boost on here since this modifier's going on all units anyway
+    // Throwing the air-airport and land-road move boost on here since this modifier's going on all units anyway
     @Override
     public void modifyMovePower(UnitContext uc)
     {
@@ -377,11 +377,19 @@ public class KaijuWarsWeapons
         return;
       if( !uc.map.isLocationValid(uc.coord) )
         return;
-      if( !uc.model.isAirUnit() )
-        return;
-      TerrainType tt = uc.map.getEnvironment(uc.coord).terrainType;
-      if( tt.healsAir() )
-        uc.movePower += 3;
+      if( uc.model.isAirUnit() )
+      {
+        TerrainType tt = uc.map.getEnvironment(uc.coord).terrainType;
+        if( tt.healsAir() )
+          uc.movePower += 3;
+      }
+      if( uc.model.isLandUnit() )
+      {
+        TerrainType tt = uc.map.getEnvironment(uc.coord).terrainType;
+        if( TerrainType.BRIDGE == tt || TerrainType.ROAD == tt )
+          uc.movePower += 2;
+      }
+      // TODO: Snow and desert (ground only) -1 move? Ruins slow awkward?
     }
   } //~KaijuWarsFightMod
 


### PR DESCRIPTION
The main relevant thing here is the final commit: it fixes coordinate-based move buffs not showing up in hypothetical threat radius calcs.

To be a bit more concrete:
This PR adds a move boost to KW land units on roads/bridges.
I noticed that the threat radius calculated while hovering a move onto a road tile was wrong (i.e. it didn't take the road-move-boost into account for the threat calc).
I fixed it.