### PR TITLE
Add a Unit Cap

### DIFF
--- a/src/AI/FightClub.java
+++ b/src/AI/FightClub.java
@@ -154,7 +154,7 @@ public class FightClub
       for( int gameIndex = 0; gameIndex < params.numGames; ++gameIndex )
       {
         GameScenario scenario = new GameScenario(mi.getValidUnitModelSchemes()[0],
-            GameScenario.DEFAULT_INCOME, GameScenario.DEFAULT_STARTING_FUNDS, FogMode.OFF_DOR, TagMode.OFF);
+            GameScenario.DEFAULT_INCOME, GameScenario.DEFAULT_STARTING_FUNDS, GameScenario.DEFAULT_UNIT_CAP, FogMode.OFF_DOR, TagMode.OFF);
 
         int numCos = mi.getNumCos();
 

--- a/src/Engine/Army.java
+++ b/src/Engine/Army.java
@@ -155,6 +155,13 @@ public class Army implements GameEventListener, Serializable, UnitModList, UnitM
         output.addAll(co.units);
     return output;
   }
+  public boolean canBuildUnits()
+  {
+    int armyCount = 0;
+    for( Commander co : cos )
+      armyCount += co.units.size();
+    return gameRules.unitCap > armyCount;
+  }
   public boolean canBuyOn(MapLocation loc)
   {
     // TODO: maybe calculate whether we have enough money to buy something at this industry

--- a/src/Engine/GameAction.java
+++ b/src/Engine/GameAction.java
@@ -153,6 +153,10 @@ public abstract class GameAction
         isValid &= site.getOwner() == who;
         isValid &= who.getShoppingList(site).contains(what);
         isValid &= (who.army.money >= who.getBuyCost(what, where));
+        int armyCount = 0;
+        for( Commander co : who.army.cos )
+          armyCount += co.units.size();
+        isValid &= who.gameRules.unitCap > armyCount;
       }
 
       if( isValid )

--- a/src/Engine/GameAction.java
+++ b/src/Engine/GameAction.java
@@ -153,10 +153,7 @@ public abstract class GameAction
         isValid &= site.getOwner() == who;
         isValid &= who.getShoppingList(site).contains(what);
         isValid &= (who.army.money >= who.getBuyCost(what, where));
-        int armyCount = 0;
-        for( Commander co : who.army.cos )
-          armyCount += co.units.size();
-        isValid &= who.gameRules.unitCap > armyCount;
+        isValid &= who.army.canBuildUnits();
       }
 
       if( isValid )

--- a/src/Engine/GameActionSet.java
+++ b/src/Engine/GameActionSet.java
@@ -11,6 +11,7 @@ public class GameActionSet
   private OptionSelector selector;
   private boolean isTargetRequired;
   public boolean useFreeSelect = false;
+  public boolean isInvalidChoice = false;
 
   public GameActionSet(GameAction action, boolean requireTarget)
   {

--- a/src/Engine/GameEvents/CreateUnitEvent.java
+++ b/src/Engine/GameEvents/CreateUnitEvent.java
@@ -68,10 +68,7 @@ public class CreateUnitEvent implements GameEvent
   @Override
   public void performEvent(MapMaster gameMap)
   {
-    int armyCount = 0;
-    for( Commander co : myCommander.army.cos )
-      armyCount += co.units.size();
-    if( null == myNewUnit || myCommander.gameRules.unitCap <= armyCount )
+    if( null == myNewUnit || !myCommander.army.canBuildUnits() )
       return;
 
     myCommander.units.add(myNewUnit);

--- a/src/Engine/GameEvents/CreateUnitEvent.java
+++ b/src/Engine/GameEvents/CreateUnitEvent.java
@@ -68,38 +68,37 @@ public class CreateUnitEvent implements GameEvent
   @Override
   public void performEvent(MapMaster gameMap)
   {
-    if( null != myNewUnit )
-    {
-      myCommander.units.add(myNewUnit);
-      if( myFudgeRadius < 1 || myBoots )
-        gameMap.addNewUnit(myNewUnit, myBuildCoords.x, myBuildCoords.y, myBoots);
-      else
-      {
-        boolean success = false;
-        UnitContext uc = new UnitContext(gameMap, myNewUnit);
-        uc.calculateMoveType();
-        // Check concentric rings outwards, to spawn as close to the original spot as possible
-        for( int radius = 0; !success && radius <= myFudgeRadius; ++radius )
-          for( XYCoord xyc : Utils.findLocationsInRange(gameMap, myBuildCoords, radius, radius) )
-          {
-            Unit resident = gameMap.getResident(xyc);
-            if( resident == null && uc.moveType.canStandOn(gameMap.getEnvironment(xyc)) )
-            {
-              gameMap.addNewUnit(myNewUnit, xyc.x, xyc.y, false);
-              success = true;
-              break;
-            }
-          }
-        if( !success )
-          System.out.println("Warning: Failed to find a place to spawn " + myNewUnit
-                            + " within " + myFudgeRadius + " tiles of " + myBuildCoords);
-      }
-      myCommander.army.myView.revealFog(myNewUnit);
-    }
+    int armyCount = 0;
+    for( Commander co : myCommander.army.cos )
+      armyCount += co.units.size();
+    if( null == myNewUnit || myCommander.gameRules.unitCap <= armyCount )
+      return;
+
+    myCommander.units.add(myNewUnit);
+    if( myFudgeRadius < 1 || myBoots )
+      gameMap.addNewUnit(myNewUnit, myBuildCoords.x, myBuildCoords.y, myBoots);
     else
     {
-      System.out.println("Warning! Attempting to build unit with insufficient funds.");
+      boolean success = false;
+      UnitContext uc = new UnitContext(gameMap, myNewUnit);
+      uc.calculateMoveType();
+      // Check concentric rings outwards, to spawn as close to the original spot as possible
+      for( int radius = 0; !success && radius <= myFudgeRadius; ++radius )
+        for( XYCoord xyc : Utils.findLocationsInRange(gameMap, myBuildCoords, radius, radius) )
+        {
+          Unit resident = gameMap.getResident(xyc);
+          if( resident == null && uc.moveType.canStandOn(gameMap.getEnvironment(xyc)) )
+          {
+            gameMap.addNewUnit(myNewUnit, xyc.x, xyc.y, false);
+            success = true;
+            break;
+          }
+        }
+      if( !success )
+        System.out.println("Warning: Failed to find a place to spawn " + myNewUnit
+                          + " within " + myFudgeRadius + " tiles of " + myBuildCoords);
     }
+    myCommander.army.myView.revealFog(myNewUnit);
   }
 
   @Override

--- a/src/Engine/GameInput/GameInputHandler.java
+++ b/src/Engine/GameInput/GameInputHandler.java
@@ -9,6 +9,7 @@ import Engine.OptionSelector;
 import Engine.XYCoord;
 import Engine.GameInput.GameInputState.StateData;
 import Terrain.GameMap;
+import UI.InGameMenu;
 import Units.Unit;
 
 /************************************************************
@@ -146,6 +147,10 @@ public class GameInputHandler
   public Object[] getMenuOptions()
   {
     return peekCurrentState().getOptions().getMenuOptions();
+  }
+  public InGameMenu<? extends Object> getMenu()
+  {
+    return peekCurrentState().getMenu();
   }
 
   /** @return The currently-recommended input mode. */

--- a/src/Engine/GameInput/GameInputState.java
+++ b/src/Engine/GameInput/GameInputState.java
@@ -13,6 +13,7 @@ import Engine.XYCoord;
 import Engine.Combat.DamagePopup;
 import Engine.GameInput.GameInputHandler.InputType;
 import Terrain.GameMap;
+import UI.InGameMenu;
 import Units.Unit;
 
 /************************************************************
@@ -45,6 +46,10 @@ abstract class GameInputState<T>
   public OptionSet getOptions()
   {
     return myOptions;
+  }
+  public InGameMenu<? extends Object> getMenu()
+  {
+    return new InGameMenu<>(getOptions().getMenuOptions(), getOptionSelector());
   }
 
   protected OptionSelector buildSelector()

--- a/src/Engine/GameInput/SelectUnitProduction.java
+++ b/src/Engine/GameInput/SelectUnitProduction.java
@@ -91,12 +91,7 @@ class SelectUnitProduction extends GameInputState<Engine.GameInput.SelectUnitPro
     ArrayList<UnitBuildOption> menuOptions = new ArrayList<>();
     int maxNameLength = 0;
     int maxPriceLength = 0;
-    int armyCount = 0;
-    boolean disableAll = false;
-    for( Commander coi : co.army.cos )
-      armyCount += coi.units.size();
-    if( co.gameRules.unitCap <= armyCount )
-      disableAll = true;
+    boolean disableAll = !co.army.canBuildUnits();
 
     // Start by getting just the unit names.
     for(UnitModel model : models)

--- a/src/Engine/GameInput/SelectUnitProduction.java
+++ b/src/Engine/GameInput/SelectUnitProduction.java
@@ -6,25 +6,24 @@ import CommandingOfficers.Commander;
 import Engine.GameAction;
 import Engine.GameActionSet;
 import Engine.XYCoord;
+import UI.InGameMenu;
+import UI.InGameMenu.MenuOption;
 import Units.UnitModel;
 
 /************************************************************
  * Presents options for building a unit.                    *
  ************************************************************/
-class SelectUnitProduction extends GameInputState<String>
+class SelectUnitProduction extends GameInputState<Engine.GameInput.SelectUnitProduction.UnitBuildOption>
 {
   private Commander builder;
-  private ArrayList<String> myStrings;
   private ArrayList<UnitModel> myUnitModels = null;
   private XYCoord myProductionLocation = null;
 
-  @SuppressWarnings("unchecked")
   public SelectUnitProduction(StateData data, Commander builder, ArrayList<UnitModel> buildables, XYCoord buildLocation)
   {
     super(data);
     this.builder = builder;
     myUnitModels = buildables;
-    myStrings = (ArrayList<String>) data.menuOptions;
     myProductionLocation = buildLocation;
   }
 
@@ -33,25 +32,22 @@ class SelectUnitProduction extends GameInputState<String>
   {
     OptionSet options = null;
     if( null != myStateData.menuOptions )
-    {
       options = new OptionSet(myStateData.menuOptions.toArray());
-    }
     return options;
   }
 
   @Override
-  public GameInputState<?> select(String option)
+  public GameInputState<?> select(UnitBuildOption option)
   {
     GameInputState<?> next = this;
 
-    if( null != option && null != myUnitModels )
+    if( null != option && option.enabled && null != myUnitModels )
     {
-      for( String buyable : myStrings )
+      for( UnitModel buyable : myUnitModels )
       {
-        if( option == buyable )
-          {
-          UnitModel model = myUnitModels.get(myStrings.indexOf(buyable));
-          myStateData.actionSet = new GameActionSet(new GameAction.UnitProductionAction(builder, model, myProductionLocation), false);
+        if( option.item == buyable )
+        {
+          myStateData.actionSet = new GameActionSet(new GameAction.UnitProductionAction(builder, buyable, myProductionLocation), false);
           next = new ActionReady(myStateData);
         }
       }
@@ -59,61 +55,66 @@ class SelectUnitProduction extends GameInputState<String>
 
     return next;
   }
+  @SuppressWarnings("unchecked")
+  @Override
+  public InGameMenu<? extends Object> getMenu()
+  {
+    return new InGameMenu<UnitModel>((ArrayList<MenuOption<UnitModel>>)myStateData.menuOptions, getOptionSelector(), true);
+  }
+
+  public static class UnitBuildOption extends MenuOption<UnitModel>
+  {
+    public String label = "";
+    public int price;
+    public UnitBuildOption(UnitModel um, int price)
+    {
+      super(um);
+      this.price = price;
+    }
+    @Override
+    public String toString()
+    {
+      return label;
+    }
+    public void bakeLabel(int nameLen, int priceLen)
+    {
+      String fmt = "%-"+nameLen+"s %"+priceLen+"d";
+      label = String.format(fmt, item.name, price);
+    }
+  }
 
   /**
    * Returns a list of strings of equal length containing the names of each unit with their respective prices.
    */
-  public static ArrayList<String> buildDisplayStrings(Commander co, ArrayList<UnitModel> models, XYCoord coord)
+  public static ArrayList<UnitBuildOption> buildDisplayStrings(Commander co, ArrayList<UnitModel> models, XYCoord coord)
   {
-    ArrayList<String> menuStrings = new ArrayList<>();
+    ArrayList<UnitBuildOption> menuOptions = new ArrayList<>();
     int maxNameLength = 0;
     int maxPriceLength = 0;
+    int armyCount = 0;
+    boolean disableAll = false;
+    for( Commander coi : co.army.cos )
+      armyCount += coi.units.size();
+    if( co.gameRules.unitCap <= armyCount )
+      disableAll = true;
 
     // Start by getting just the unit names.
     for(UnitModel model : models)
     {
-      // Store each string and record the max length.
-      String str = model.name;
-      menuStrings.add( str );
-      maxNameLength = Math.max(maxNameLength, str.length());
-      maxPriceLength = Math.max(maxPriceLength, Integer.toString(co.getBuyCost(model, coord)).length());
+      int price = co.getBuyCost(model, coord);
+      menuOptions.add(new UnitBuildOption(model, price));
+      maxNameLength  = Math.max(maxNameLength, model.name.length());
+      maxPriceLength = Math.max(maxPriceLength, Integer.toString(price).length());
     }
 
-    maxNameLength++; // Add 1 for a space between unit name and price.
-
-    // Modify each String to include the price at a set tab level.
-    StringBuilder sb = new StringBuilder();
-    for( int i = 0; i < models.size(); ++i, sb.setLength(0) )
+    for( UnitBuildOption ubo : menuOptions )
     {
-      // Start with the production item name.
-      sb.append( menuStrings.get(i) );
-
-      // Get the price as a string.
-      String price = "";
-      UnitModel model = models.get(i);
-      if( null == model )
-      {
-        System.out.println("WARNING: null UnitModel encountered in production menu! Skipping.");
-        continue;
-      }
-      else
-      {
-        price = Integer.toString(co.getBuyCost(model, coord));
-      }
-
-      // Find the difference between the max length and current length
-      int neededSpace = maxNameLength + maxPriceLength - price.length() - sb.length();
-      // Append spaces until this entry is the approved length.
-      for( int j = 0; j < neededSpace; ++j )
-        sb.append(" ");
-
-      // Append the actual cost of the item.
-      sb.append(price);
-
-      // Plug the new string into the return list.
-      menuStrings.set(i, sb.toString());
+      if( ubo.price > co.army.money || disableAll )
+        ubo.enabled = false;
+      ubo.bakeLabel(maxNameLength, maxPriceLength);
     }
-    return menuStrings;
+
+    return menuOptions;
   }
   
 }

--- a/src/Engine/GameScenario.java
+++ b/src/Engine/GameScenario.java
@@ -13,20 +13,17 @@ public class GameScenario implements Serializable
   private static final long serialVersionUID = 1L;
   public final static int DEFAULT_INCOME = 1000;
   public final static int DEFAULT_STARTING_FUNDS = 0;
+  public final static int DEFAULT_UNIT_CAP = 50;
 
   public final GameRules rules;
 
   public GameScenario()
   {
-    this(DEFAULT_INCOME, DEFAULT_STARTING_FUNDS);
+    this(new AWBWUnits(), DEFAULT_INCOME, DEFAULT_STARTING_FUNDS, DEFAULT_UNIT_CAP, FogMode.OFF_DOR, TagMode.OFF);
   }
-  public GameScenario(int income, int startFunds)
+  public GameScenario(UnitModelScheme scheme, int income, int startFunds, int units, FogMode fog, TagMode tags)
   {
-    rules = new GameRules(new AWBWUnits(), income, startFunds, FogMode.OFF_DOR, TagMode.OFF);
-  }
-  public GameScenario(UnitModelScheme scheme, int income, int startFunds, FogMode fog, TagMode tags)
-  {
-    rules = new GameRules(scheme, income, startFunds, fog, tags);
+    rules = new GameRules(scheme, income, startFunds, units, fog, tags);
   }
 
   public GameEventQueue initTurn(GameMap map)
@@ -71,14 +68,16 @@ public class GameScenario implements Serializable
     private static final long serialVersionUID = 1L;
     public final int incomePerCity;
     public final int startingFunds;
+    public final int unitCap;
     public final UnitModelScheme unitModelScheme;
     public final TagMode tagMode;
     public FogMode fogMode;
 
-    public GameRules(UnitModelScheme ums, int income, int startFunds, FogMode fog, TagMode tags)
+    public GameRules(UnitModelScheme ums, int income, int startFunds, int units, FogMode fog, TagMode tags)
     {
       incomePerCity = income;
       startingFunds = startFunds;
+      unitCap = units;
       unitModelScheme = ums;
       tagMode = tags;
       fogMode = fog;

--- a/src/Engine/MapController.java
+++ b/src/Engine/MapController.java
@@ -411,7 +411,7 @@ public class MapController implements IController, GameInputHandler.StateChanged
             myGame.setCursorLocation(coord);
           }
         }
-        currentMenu = new InGameMenu<>(myGameInputHandler.getMenuOptions(), myGameInputOptionSelector);
+        currentMenu = myGameInputHandler.getMenu();
         break;
       case ACTION_READY:
         if( null != myGameInputHandler.getReadyAction() )

--- a/src/Engine/UnitActionFactory.java
+++ b/src/Engine/UnitActionFactory.java
@@ -19,6 +19,10 @@ public abstract class UnitActionFactory implements Serializable
 {
   private static final long serialVersionUID = 1L;
 
+  public GameActionSet getGUIActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
+  {
+    return getPossibleActions(map, movePath, actor, ignoreResident);
+  }
   public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor)
   {
     return getPossibleActions(map, movePath, actor, false);

--- a/src/Engine/UnitActionLifecycles/UnitProduceLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/UnitProduceLifecycle.java
@@ -28,6 +28,25 @@ public abstract class UnitProduceLifecycle
       typeToBuild = type;
     }
 
+    // Provide an invalid option if it has materials
+    @Override
+    public GameActionSet getGUIActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
+    {
+      GameActionSet realActions = getPossibleActions(map, movePath, actor, ignoreResident);
+      if( null == realActions )
+      {
+        XYCoord moveLocation = movePath.getEndCoord();
+        if( moveLocation.equals(actor.x, actor.y)
+            && actor.hasMaterials() )
+        {
+          GameActionSet gas = new GameActionSet(new UnitProduceAction(this, actor), false);
+          gas.isInvalidChoice = true;
+          return gas;
+        }
+      }
+      return realActions;
+    }
+
     @Override
     public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
     {

--- a/src/Engine/UnitActionLifecycles/UnitProduceLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/UnitProduceLifecycle.java
@@ -31,9 +31,14 @@ public abstract class UnitProduceLifecycle
     @Override
     public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
     {
+      int armyCount = 0;
+      for( Commander co : actor.CO.army.cos )
+        armyCount += co.units.size();
+
       XYCoord moveLocation = movePath.getEndCoord();
       if( moveLocation.equals(actor.x, actor.y) && actor.hasCargoSpace(typeToBuild.role)
           && actor.CO.army.money >= actor.CO.getCost(typeToBuild)
+          && actor.CO.gameRules.unitCap > armyCount
           && actor.hasMaterials() )
       {
         return new GameActionSet(new UnitProduceAction(this, actor), false);

--- a/src/Engine/UnitActionLifecycles/UnitProduceLifecycle.java
+++ b/src/Engine/UnitActionLifecycles/UnitProduceLifecycle.java
@@ -50,14 +50,10 @@ public abstract class UnitProduceLifecycle
     @Override
     public GameActionSet getPossibleActions(GameMap map, GamePath movePath, Unit actor, boolean ignoreResident)
     {
-      int armyCount = 0;
-      for( Commander co : actor.CO.army.cos )
-        armyCount += co.units.size();
-
       XYCoord moveLocation = movePath.getEndCoord();
       if( moveLocation.equals(actor.x, actor.y) && actor.hasCargoSpace(typeToBuild.role)
           && actor.CO.army.money >= actor.CO.getCost(typeToBuild)
-          && actor.CO.gameRules.unitCap > armyCount
+          && actor.CO.army.canBuildUnits()
           && actor.hasMaterials() )
       {
         return new GameActionSet(new UnitProduceAction(this, actor), false);
@@ -171,19 +167,14 @@ public abstract class UnitProduceLifecycle
     @Override
     public void performEvent(MapMaster gameMap)
     {
-      if( null != myNewUnit )
-      {
-        myCommander.army.money -= cost;
-        if( builder.model.needsMaterials )
-          builder.materials -= 1;
-        myCommander.units.add(myNewUnit);
-        builder.heldUnits.add(myNewUnit);
-        builder.isTurnOver = true;
-      }
-      else
-      {
-        System.out.println("Warning! Attempting to build unit with insufficient funds.");
-      }
+      if( null == myNewUnit || !myCommander.army.canBuildUnits() )
+        return;
+      myCommander.army.money -= cost;
+      if( builder.model.needsMaterials )
+        builder.materials -= 1;
+      myCommander.units.add(myNewUnit);
+      builder.heldUnits.add(myNewUnit);
+      builder.isTurnOver = true;
     }
 
     @Override

--- a/src/UI/Art/SpriteArtist/Backgrounds/DiagonalBlindsBG.java
+++ b/src/UI/Art/SpriteArtist/Backgrounds/DiagonalBlindsBG.java
@@ -46,10 +46,8 @@ public class DiagonalBlindsBG
     // Build the polygon we will use to draw the lighter bands in the background.
     int[] xPoints = {0, dimensions.height, dimensions.height+shimmerThickness, shimmerThickness};
     int[] yPoints = {dimensions.height, 0, 0, dimensions.height};
-    Polygon shimmerPoly = new Polygon(xPoints, yPoints, xPoints.length); // Shimmer shape to draw.
+    Polygon drawPoly = new Polygon(xPoints, yPoints, xPoints.length); // Shimmer shape to draw.
 
-    // Make a copy of the base polygon and translate it to the first draw point.
-    Polygon drawPoly = new Polygon(shimmerPoly.xpoints, shimmerPoly.ypoints, shimmerPoly.npoints);
     int currentDrawPoint = (int)shimmerBasePoint; // Get the basis point to the nearest pixel.
     drawPoly.translate(currentDrawPoint, 0);
 

--- a/src/UI/Art/SpriteArtist/MenuArtist.java
+++ b/src/UI/Art/SpriteArtist/MenuArtist.java
@@ -3,7 +3,6 @@ package UI.Art.SpriteArtist;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.image.BufferedImage;
-import java.util.ArrayList;
 
 import Engine.GameInstance;
 import UI.InGameMenu;
@@ -13,8 +12,6 @@ public class MenuArtist
 {
   private GameInstance myGame;
   private MapView myView;
-  private InGameMenu<? extends Object> myCurrentMenu;
-  private ArrayList<String> myCurrentMenuStrings;
 
   private int menuHBuffer; // Amount of visible menu to left and right of options;
   private int menuVBuffer; // Amount of visible menu above and below menu options;
@@ -22,8 +19,6 @@ public class MenuArtist
   public MenuArtist(GameInstance game, SpriteMapView view)
   {
     myGame = game;
-    myCurrentMenu = null;
-    myCurrentMenuStrings = new ArrayList<String>();
 
     myView = view;
 
@@ -40,16 +35,8 @@ public class MenuArtist
     InGameMenu<? extends Object> drawMenu = myView.getCurrentGameMenu();
     if( drawMenu != null )
     {
-      // Check if we need to build the menu options again.
-      if( drawMenu.wasReset() || myCurrentMenu != drawMenu )
-      {
-        myCurrentMenu = drawMenu;
-        myCurrentMenuStrings.clear();
-        getMenuStrings(myCurrentMenu, myCurrentMenuStrings);
-      }
-
       BufferedImage menu = SpriteUIUtils.makeTextMenu(SpriteUIUtils.MENUBGCOLOR, SpriteUIUtils.MENUFRAMECOLOR, SpriteUIUtils.MENUHIGHLIGHTCOLOR,
-          myCurrentMenuStrings, myCurrentMenu.getSelectionNumber(), menuHBuffer, menuVBuffer);
+          drawMenu.getAllOptions(), drawMenu.getSelectionNumber(), menuHBuffer, menuVBuffer);
       int menuWidth = menu.getWidth();
       int menuHeight = menu.getHeight();
 
@@ -71,20 +58,6 @@ public class MenuArtist
       drawY -= Math.max(0, drawY + menuHeight - myGame.gameMap.mapHeight * viewTileSize); // bottom
 
       g.drawImage(menu, drawX, drawY, menuWidth, menuHeight, null);
-    }
-  }
-
-  /**
-   * Populate 'out' with the string versions of the options available through 'menu'.
-   * @param menu
-   * @param out
-   */
-  private static void getMenuStrings(InGameMenu<? extends Object> menu, ArrayList<String> out)
-  {
-    for( int i = 0; i < menu.getNumOptions(); ++i )
-    {
-      String str = menu.getOptionString(i);
-      out.add(str);
     }
   }
 }

--- a/src/UI/Art/SpriteArtist/SpriteUIUtils.java
+++ b/src/UI/Art/SpriteArtist/SpriteUIUtils.java
@@ -18,8 +18,9 @@ public class SpriteUIUtils
   public static final Color MENUFRAMECOLOR = new Color(169, 118, 65);
   public static final Color MENUBGCOLOR = new Color(234, 204, 154);
   public static final Color MENUHIGHLIGHTCOLOR = new Color(246, 234, 210);
-  public static final Color MENUDISABLECOLOR = new Color(100, 100, 100);
-  public static final int DIAGONAL_MIX_WIDTH = 42;
+  public static final Color MENUDISABLECOLOR = new Color(170, 170, 170);
+  public static final int DIAGONAL_MIX_WIDTH = 7;
+  public static final int DIAGONAL_MIX_SPACE = 10;
 
 
   public static BufferedImage makeTextFrame(String item, int hBuffer, int vBuffer)
@@ -76,15 +77,15 @@ public class SpriteUIUtils
         int[] yPoints = {selY+menuTextHeight, selY, selY, selY+menuTextHeight};
         Polygon drawPoly = new Polygon(xPoints, yPoints, xPoints.length); // Shimmer shape to draw.
 
-        int currentDrawPoint = i * DIAGONAL_MIX_WIDTH;
-        drawPoly.translate(currentDrawPoint, selY);
+        int currentDrawPoint = 0;
+        drawPoly.translate(currentDrawPoint, 0);
 
         g.setColor(focus);
-        for(; currentDrawPoint < menuWidth; currentDrawPoint += DIAGONAL_MIX_WIDTH)
+        for(; currentDrawPoint < menuWidth; currentDrawPoint += DIAGONAL_MIX_SPACE)
         {
           // Draw the current shimmering band, then translate the polygon for the next.
           g.fillPolygon(drawPoly);
-          drawPoly.translate(DIAGONAL_MIX_WIDTH, 0);
+          drawPoly.translate(DIAGONAL_MIX_SPACE, 0);
         }
       }
     }

--- a/src/UI/GameBuilder.java
+++ b/src/UI/GameBuilder.java
@@ -22,8 +22,9 @@ public class GameBuilder
 {
   public MapInfo mapInfo;
   public FogMode fogMode = FogMode.OFF_TRILOGY;
-  public int startingFunds = 0;
-  public int incomePerCity = 1000;
+  public int startingFunds = GameScenario.DEFAULT_STARTING_FUNDS;
+  public int incomePerCity = GameScenario.DEFAULT_INCOME;
+  public int unitCap       = GameScenario.DEFAULT_UNIT_CAP;
   public Weathers defaultWeather = Weathers.CLEAR;
   public UnitModelScheme unitModelScheme = null;
   public TagMode tagMode = TagMode.OFF;
@@ -36,7 +37,7 @@ public class GameBuilder
 
   public GameInstance createGame(PlayerSetupInfo[] playerInfos)
   {
-    GameScenario scenario = new GameScenario(unitModelScheme, incomePerCity, startingFunds, fogMode, tagMode);
+    GameScenario scenario = new GameScenario(unitModelScheme, incomePerCity, startingFunds, unitCap, fogMode, tagMode);
 
     // Add any CO-specific units into our set of UnitModels
     for( PlayerSetupInfo player : playerInfos )

--- a/src/UI/GameOptionSetupController.java
+++ b/src/UI/GameOptionSetupController.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Scanner;
 
 import Engine.ConfigUtils;
+import Engine.GameScenario;
 import Engine.IController;
 import Engine.OptionSelector;
 import Terrain.Environment.Weathers;
@@ -18,8 +19,9 @@ public class GameOptionSetupController implements IController
   public final int GAME_OPTIONS_CONFIG_KEY = -1; // Player indices start at 0, so -1 should be safe.
 
   private GameOption<FogMode> fowOption = new GameOption<FogMode>("Fog of War", FogMode.values(), 0);
-  private GameOption<Integer> startingFundsOption = new GameOptionInt("Starting Funds", 0, 50000, 1000, 0);
-  private GameOption<Integer> incomeOption = new GameOptionInt("Income", 0, 20000, 250, 1000);
+  private GameOption<Integer> startingFundsOption = new GameOptionInt("Starting Funds", 0, 50000, 1000, GameScenario.DEFAULT_STARTING_FUNDS);
+  private GameOption<Integer> incomeOption = new GameOptionInt("Income", 0, 20000, 250, GameScenario.DEFAULT_INCOME);
+  private GameOption<Integer> unitCapOption = new GameOptionInt("Unit Cap", 0, 1000, 1, GameScenario.DEFAULT_UNIT_CAP);
   private GameOption<Weathers> weatherOption = new GameOption<Weathers>("Weather", Weathers.values(), 0);
   private GameOption<UnitModelScheme> unitSchemeOption;
   private GameOption<TagMode> tagsOption = new GameOption<TagMode>("Tag Mode", TagMode.values(), 0);
@@ -49,7 +51,7 @@ public class GameOptionSetupController implements IController
     for (int i = 0; !unitSchemeOption.getSelectedObject().schemeValid && i < unitSchemeOption.size(); ++i )
       unitSchemeOption.setSelectedOption(i);
 
-    gameOptions = new GameOption<?>[] {fowOption, startingFundsOption, incomeOption, weatherOption, unitSchemeOption, tagsOption, securityOption};
+    gameOptions = new GameOption<?>[] {fowOption, startingFundsOption, incomeOption, weatherOption, unitSchemeOption, unitCapOption, tagsOption, securityOption};
     optionSelector = new OptionSelector( gameOptions.length );
 
     // Read in the last settings we used on this map, if available
@@ -130,6 +132,7 @@ public class GameOptionSetupController implements IController
         gameBuilder.fogMode       = fowOption.getSelectedObject();
         gameBuilder.startingFunds = startingFundsOption.getSelectedObject();
         gameBuilder.incomePerCity = incomeOption.getSelectedObject();
+        gameBuilder.unitCap       = unitCapOption.getSelectedObject();
         gameBuilder.defaultWeather = (Weathers)weatherOption.getSelectedObject();
         gameBuilder.unitModelScheme = unitSchemeOption.getSelectedObject();
         gameBuilder.tagMode = (TagMode)tagsOption.getSelectedObject();

--- a/src/UI/GameOptionSetupController.java
+++ b/src/UI/GameOptionSetupController.java
@@ -63,14 +63,15 @@ public class GameOptionSetupController implements IController
 
     if( initialPicksMap.containsKey(GAME_OPTIONS_CONFIG_KEY) )
     {
+      GameOption<?>[] chronologicalOptions = new GameOption<?>[] {fowOption, startingFundsOption, incomeOption, weatherOption, unitSchemeOption, tagsOption, securityOption, unitCapOption};
       String fullConfig = initialPicksMap.get(GAME_OPTIONS_CONFIG_KEY);
-      String[] s = fullConfig.split("\\s+"); // Split (string integers)
-      int si = 0; // Split Index
-      while (s[si].isEmpty()) ++si; // Skip any sneaky empty splits
+      String[] configInts = fullConfig.split("\\s+"); // Split (string integers)
+      int configIndex = 0; // Split Index
+      while (configInts[configIndex].isEmpty()) ++configIndex; // Skip empty splits at the start
 
-      for( int i = 0; i < gameOptions.length; ++i )
-        if( s.length > si )
-          gameOptions[i].setSelectedOption(Integer.valueOf(s[si++]));
+      for( int i = 0; i < chronologicalOptions.length; ++i )
+        if( configInts.length > configIndex )
+          chronologicalOptions[i].setSelectedOption(Integer.valueOf(configInts[configIndex++]));
     }
     else
     {

--- a/src/UI/InGameMenu.java
+++ b/src/UI/InGameMenu.java
@@ -14,7 +14,21 @@ import Engine.OptionSelector;
  */
 public class InGameMenu<T>
 {
-  private ArrayList<T> menuOptions;
+  public static class MenuOption<T>
+  {
+    public final T item;
+    public boolean enabled = true;
+    public MenuOption(T arg)
+    {
+      item = arg;
+    }
+    @Override
+    public String toString()
+    {
+      return "" + item;
+    }
+  }
+  private ArrayList<MenuOption<T>> menuOptions;
 
   private OptionSelector optionSelector;
 
@@ -41,8 +55,9 @@ public class InGameMenu<T>
   {
     if (options.size() != selector.size())
       throw new IllegalArgumentException("Number of options doesn't match the size of the OptionSelector");
-    menuOptions = new ArrayList<T>();
-    menuOptions.addAll(options);
+    menuOptions = new ArrayList<>();
+    for( T opt : options )
+      menuOptions.add(new MenuOption<T>(opt));
     optionSelector = selector;
     wasReset = true;
   }
@@ -59,7 +74,7 @@ public class InGameMenu<T>
    * Re-initializes this object with the new set of options.
    * @param newOptions
    */
-  public void resetOptions(Collection<T> newOptions)
+  public void resetOptions(Collection<MenuOption<T>> newOptions)
   {
     menuOptions.clear();
     menuOptions.addAll(newOptions);
@@ -71,10 +86,10 @@ public class InGameMenu<T>
    * Re-initializes this object with the new set of options.
    * @param newOptions
    */
-  public void resetOptions(T[] newOptions)
+  public void resetOptions(MenuOption<T>[] newOptions)
   {
     menuOptions.clear();
-    for( T t : newOptions )
+    for( MenuOption<T> t : newOptions )
     {
       menuOptions.add(t);
     }
@@ -86,7 +101,7 @@ public class InGameMenu<T>
    * Re-initializes this object with the new set of options.
    * @param newOptions
    */
-  public void resetOptions(ArrayList<T> newOptions)
+  public void resetOptions(ArrayList<MenuOption<T>> newOptions)
   {
     menuOptions.clear();
     menuOptions.addAll(newOptions);
@@ -149,7 +164,7 @@ public class InGameMenu<T>
   /**
    * @return The object currently highlighted by the menu cursor.
    */
-  public T getSelectedOption()
+  public MenuOption<T> getSelectedOption()
   {
     return menuOptions.get( optionSelector.getSelectionNormalized() );
   }
@@ -157,7 +172,7 @@ public class InGameMenu<T>
   /**
    * @return The object at the specified index.
    */
-  public T getOption( int index )
+  public MenuOption<T> getOption( int index )
   {
     if( menuOptions.size() > index && index >= 0 )
     {
@@ -184,12 +199,12 @@ public class InGameMenu<T>
   /**
    * Returns string representations of all menu options.
    */
-  public ArrayList<String> getAllOptions()
+  public ArrayList<MenuOption<? extends Object>> getAllOptions()
   {
-    ArrayList<String> out = new ArrayList<String>();
-    for (T option : menuOptions)
+    ArrayList<MenuOption<? extends Object>> out = new ArrayList<>();
+    for (MenuOption<T> option : menuOptions)
     {
-      out.add(option.toString());
+      out.add(option);
     }
     return out;
   }

--- a/src/UI/InGameMenu.java
+++ b/src/UI/InGameMenu.java
@@ -28,7 +28,7 @@ public class InGameMenu<T>
       return "" + item;
     }
   }
-  private ArrayList<MenuOption<T>> menuOptions;
+  private ArrayList<MenuOption<? extends T>> menuOptions;
 
   private OptionSelector optionSelector;
 
@@ -61,6 +61,14 @@ public class InGameMenu<T>
     optionSelector = selector;
     wasReset = true;
   }
+  public InGameMenu(Collection<MenuOption<T>> options, OptionSelector selector, boolean garbage) // extra param to differentiate this overload
+  {
+    if (options.size() != selector.size())
+      throw new IllegalArgumentException("Number of options doesn't match the size of the OptionSelector");
+    menuOptions = new ArrayList<>(options);
+    optionSelector = selector;
+    wasReset = true;
+  }
 
   /**
    * Set the selection back to the first option.
@@ -74,10 +82,11 @@ public class InGameMenu<T>
    * Re-initializes this object with the new set of options.
    * @param newOptions
    */
-  public void resetOptions(Collection<MenuOption<T>> newOptions)
+  public void resetOptions(Collection<MenuOption<? extends T>> newOptions)
   {
     menuOptions.clear();
-    menuOptions.addAll(newOptions);
+    for( MenuOption<? extends T> opt : newOptions )
+      menuOptions.add(opt);
     optionSelector.reset( menuOptions.size() );
     wasReset = true;
   }
@@ -86,10 +95,10 @@ public class InGameMenu<T>
    * Re-initializes this object with the new set of options.
    * @param newOptions
    */
-  public void resetOptions(MenuOption<T>[] newOptions)
+  public void resetOptions(MenuOption<? extends T>[] newOptions)
   {
     menuOptions.clear();
-    for( MenuOption<T> t : newOptions )
+    for( MenuOption<? extends T> t : newOptions )
     {
       menuOptions.add(t);
     }
@@ -164,7 +173,7 @@ public class InGameMenu<T>
   /**
    * @return The object currently highlighted by the menu cursor.
    */
-  public MenuOption<T> getSelectedOption()
+  public MenuOption<? extends T> getSelectedOption()
   {
     return menuOptions.get( optionSelector.getSelectionNormalized() );
   }
@@ -172,7 +181,7 @@ public class InGameMenu<T>
   /**
    * @return The object at the specified index.
    */
-  public MenuOption<T> getOption( int index )
+  public MenuOption<? extends T> getOption( int index )
   {
     if( menuOptions.size() > index && index >= 0 )
     {
@@ -202,7 +211,7 @@ public class InGameMenu<T>
   public ArrayList<MenuOption<? extends Object>> getAllOptions()
   {
     ArrayList<MenuOption<? extends Object>> out = new ArrayList<>();
-    for (MenuOption<T> option : menuOptions)
+    for (MenuOption<? extends T> option : menuOptions)
     {
       out.add(option);
     }

--- a/src/UI/InGameMenu.java
+++ b/src/UI/InGameMenu.java
@@ -43,12 +43,12 @@ public class InGameMenu<T>
 
   public InGameMenu(T[] options)
   {
-    this(new ArrayList<T>(Arrays.asList(options)));
+    this(Arrays.asList(options));
   }
 
   public InGameMenu(T[] options, OptionSelector selector)
   {
-    this(new ArrayList<T>(Arrays.asList(options)), selector);
+    this(Arrays.asList(options), selector);
   }
 
   public InGameMenu(Collection<T> options, OptionSelector selector)

--- a/src/UI/MainUIController.java
+++ b/src/UI/MainUIController.java
@@ -186,7 +186,7 @@ public class MainUIController implements IController
     {
       case SELECT:
         // Grab the selected option.
-        SubMenu chosenOption = optionsMenu.getSelectedOption();
+        SubMenu chosenOption = optionsMenu.getSelectedOption().item;
         optionsMenu = null; // We are done with this until next time.
 
         if( optionsSubMenus.contains(chosenOption) )
@@ -211,7 +211,7 @@ public class MainUIController implements IController
     {
       case SELECT:
         // Grab the current option and roll it back to within the valid range, then evaluate.
-        SaveInfo chosenOption = saveMenu.getSelectedOption();
+        SaveInfo chosenOption = saveMenu.getSelectedOption().item;
 
         // We've already successfully read the save file, so let's assume the user isn't messing with us
         GameInstance oldGame = SerializationUtils.loadSave(chosenOption.filePath);

--- a/src/Units/Unit.java
+++ b/src/Units/Unit.java
@@ -178,6 +178,21 @@ public class Unit extends UnitState implements UnitModList
 
     return actionSet;
   }
+  public ArrayList<GameActionSet> getGUIActions(GameMap map, GamePath movePath)
+  {
+    boolean ignoreResident = false;
+    UnitContext uc = new UnitContext(map, this);
+
+    ArrayList<GameActionSet> actionSet = new ArrayList<GameActionSet>();
+    for( UnitActionFactory at : uc.calculateActionTypes() )
+    {
+      GameActionSet actions = at.getGUIActions(map, movePath, this, ignoreResident);
+      if( null != actions )
+        actionSet.add(actions);
+    }
+
+    return actionSet;
+  }
 
   public boolean hasActionType(UnitActionFactory UnitActionType)
   {


### PR DESCRIPTION
This has to go on top of the YC changes since they both tweak `CreateUnitEvent` - YC to expose the new unit's health for meddling (for Sensei), this to enable preventing it from spawning.

Pursuant to your complaint, I also added a GUI thing so options can be flagged as invalid:
![image](https://github.com/user-attachments/assets/2bdde4da-d12a-4fdd-93ce-8ad6f63bb5d6)
This, of course, led to me throwing the option of invalid options onto arty firing and production actions, for UX-y reasons.

I'm not at all certain this is a good design, but it does seem to function, which is a nice feature.

I am also aware this kinda-sorta breaks our AIs, so I've added an AI constraint test on another branch: `aiunitcap`
I'm not gonna make the test pass just yet, since there are two AI PRs in the air at the moment.