### PR TITLE
Weathernanigans

### DIFF
--- a/src/CommandingOfficers/AW3/BM/Olaf.java
+++ b/src/CommandingOfficers/AW3/BM/Olaf.java
@@ -38,10 +38,12 @@ public class Olaf extends AW3Commander
           + "Winter weather poses no problem for Olaf or his troops. Snow causes his firepower to rise, and his troops can move with no penalty.\n"
           + "(Normal movement and +20 attack in cold weather.)"));
       infoPages.add(new InfoPage(new Blizzard(null, null),
-            "Causes chill (doubled fuel consumption) for two days.\n"
+            "Causes cold weather (doubled fuel consumption) for two days.\n"
+          + "Disables temporary fog, if it's active.\n"
           + "+10 attack and defense.\n"));
       infoPages.add(new InfoPage(new WinterFury(null, null),
-            "A mighty blizzard causes two HP of damage to all enemy troops. The chill also persists for two days.\n"
+            "A mighty blizzard causes two HP of damage to all enemy troops. The cold weather also persists for two days.\n"
+          + "Disables temporary fog, if it's active.\n"
           + "+10 attack and defense.\n"));
       infoPages.add(new InfoPage(
             "Hit: Warm Boots\n"
@@ -95,10 +97,11 @@ public class Olaf extends AW3Commander
     @Override
     public GameEventQueue getEvents(MapMaster map)
     {
-      GameEvent event = new GlobalWeatherEvent(Weathers.CHILL, 2);
+      GlobalWeatherEvent weather = new GlobalWeatherEvent(Weathers.CHILL, 2);
+      weather.canCancelFog = true;
 
       GameEventQueue events = new GameEventQueue();
-      events.add(event);
+      events.add(weather);
 
       return events;
     }
@@ -119,7 +122,8 @@ public class Olaf extends AW3Commander
     @Override
     public GameEventQueue getEvents(MapMaster map)
     {
-      GameEvent weather = new GlobalWeatherEvent(Weathers.CHILL, 2);
+      GlobalWeatherEvent weather = new GlobalWeatherEvent(Weathers.CHILL, 2);
+      weather.canCancelFog = true;
 
       ArrayList<Unit> victims = COutils.findMassDamageTargets(map, myCommander);
       GameEvent damage = new MassDamageEvent(myCommander, victims, 20, false);

--- a/src/CommandingOfficers/AW4/IDS/Penny.java
+++ b/src/CommandingOfficers/AW4/IDS/Penny.java
@@ -1,17 +1,19 @@
 package CommandingOfficers.AW4.IDS;
 
+import java.util.ArrayList;
+
 import CommandingOfficers.Commander;
 import CommandingOfficers.CommanderInfo;
 import CommandingOfficers.DeployableCommander;
 import CommandingOfficers.AW4.RuinedCommander;
 import Engine.GameScenario;
-import Engine.GameEvents.GameEvent;
 import Engine.GameEvents.GameEventQueue;
 import Engine.GameEvents.GlobalWeatherEvent;
 import Terrain.MapMaster;
 import Terrain.TerrainType;
 import Terrain.Environment.Weathers;
 import UI.UIUtils;
+import Units.Unit;
 import Units.UnitContext;
 
 public class Penny extends RuinedCommander
@@ -83,11 +85,16 @@ public class Penny extends RuinedCommander
     @Override
     public GameEventQueue getEvents(MapMaster map)
     {
-      Weathers[] candidates = { Weathers.SLEET, Weathers.SMOKE, Weathers.SIROCCO };
-      int rand = map.game.getRN(candidates.length);
+      ArrayList<Weathers> candidates = new ArrayList<>();
+      candidates.add(Weathers.SLEET);
+      candidates.add(Weathers.SMOKE);
+      candidates.add(Weathers.SIROCCO);
+      for( Unit u : COcast.COUs ) // Don't roll the same weather that's currently active
+        candidates.remove(map.getEnvironment(u.x, u.y).weatherType);
+      int rand = map.game.getRN(candidates.size());
 
-      Weathers chosen = candidates[rand];
-      GameEvent weather = new GlobalWeatherEvent(chosen, 3);
+      Weathers chosen = candidates.get(rand);
+      GlobalWeatherEvent weather = new GlobalWeatherEvent(chosen, 3);
 
       GameEventQueue events = super.getEvents(map);
       events.add(weather);

--- a/src/CommandingOfficers/AW4/IDS/Penny.java
+++ b/src/CommandingOfficers/AW4/IDS/Penny.java
@@ -33,7 +33,9 @@ public class Penny extends RuinedCommander
           "Base Zone: 3\n"
         + "Units are unaffected by weather. This applies even when not in the CO Zone.\n"));
       infoPages.add(new InfoPage(new Stormfront(null),
-          "Randomly changes the weather to Sleet (-1 move), Smoke (Fog of War), or Sirocco (-30 attack). The weather lasts for 3 days.\n"));
+          "Randomly changes the weather to Sleet (-1 move), Smoke (Fog of War), or Sirocco (-30 attack). The weather lasts for 3 days.\n"
+        + "Won't roll the weather active on the COU's tile.\n"
+        + "If Sleet or Sirocco is rolled, disables temporary fog.\n"));
       infoPages.add(DeployableCommander.COU_MECHANICS_BLURB);
       infoPages.add(RuinedCommander.DOR_MECHANICS_BLURB);
     }
@@ -95,6 +97,7 @@ public class Penny extends RuinedCommander
 
       Weathers chosen = candidates.get(rand);
       GlobalWeatherEvent weather = new GlobalWeatherEvent(chosen, 3);
+      weather.canCancelFog = true;
 
       GameEventQueue events = super.getEvents(map);
       events.add(weather);

--- a/src/CommandingOfficers/AW4/RuinedCommander.java
+++ b/src/CommandingOfficers/AW4/RuinedCommander.java
@@ -336,7 +336,7 @@ public abstract class RuinedCommander extends DeployableCommander
   {
     private static final long serialVersionUID = 1L;
     public static final int COST = 6;
-    RuinedCommander COcast;
+    protected RuinedCommander COcast;
 
     protected RuinedAbility(RuinedCommander commander, String name)
     {

--- a/src/Engine/GameEvents/GlobalWeatherEvent.java
+++ b/src/Engine/GameEvents/GlobalWeatherEvent.java
@@ -15,6 +15,7 @@ public class GlobalWeatherEvent implements GameEvent
 {
   private Weathers weather;
   private int duration;
+  public boolean canCancelFog = false; // If temporary fog is active and the weather doesn't create fog, cancel it.
 
   /** Changes the whole map to the given weather. */
   public GlobalWeatherEvent(Weathers newWeather)
@@ -52,6 +53,12 @@ public class GlobalWeatherEvent implements GameEvent
         loc.setForecast(weather, (map.game.armies.length * duration) - 1);
       }
     }
+    for( Army a : map.game.armies )
+      a.myView.revealFog(); // In case this removed some vision penalties.
+
+    if( map.game.rules.fogMode.fogDefaultsOn )
+      return;
+    // Beyond here is logic that turns on/off global fog in non-fog games.
     if( weather.startsFog )
     {
       map.game.setFog(duration);
@@ -61,6 +68,12 @@ public class GlobalWeatherEvent implements GameEvent
           continue; // This is probably technically laxer than it should be (allows allies to watch your turn with full vision in DoR fog), but like... it seems more fun to see things than not.
         a.myView.resetFog();
       }
+    }
+    else if( canCancelFog )
+    {
+      map.game.setFog(-1); // 0 would make it active for this turn.
+      for( Army a : map.game.armies )
+        a.myView.resetFog();
     }
   }
 

--- a/src/Engine/GameEvents/UnitDieEvent.java
+++ b/src/Engine/GameEvents/UnitDieEvent.java
@@ -47,16 +47,15 @@ public class UnitDieEvent implements GameEvent
     gameMap.removeUnit(unit);
     unit.CO.units.remove(unit);
 
-    // We need to take vision away immediately if your unit dies off-turn (specifically for DoR fog)
+    // We need to take vision away immediately if your unit dies either:
+    // off-turn (especially for DoR fog)
+    // on-turn (for Trilogy fog, but *not* DoR fog)
     Army activeArmy = gameMap.game.activeArmy;
-    if( activeArmy != unit.CO.army )
+    if( activeArmy != unit.CO.army || !activeArmy.gameRules.fogMode.dorMode )
     {
       for( Army army : gameMap.game.armies )
-      {
-        if( army == activeArmy )
-          continue;
-        army.myView.resetFog();
-      }
+        if( army.team == unit.CO.army.team )
+          army.myView.resetFog();
     }
   }
 


### PR DESCRIPTION
This PR fixes some interactions with DS/DoR-style rain and powers that can cancel the fog it brings (since fog state and weather state aren't linked in the same way here).

I'm not giving this effect to AW1/2 Olaf/Drake, for a few reasons:
They never interact with fog-bringing weather on cart.
They produce only a single day of weather, which would still (in the current implementation) cancel the entire N-day sequence.
Their weather effects are substantive on their own.

This does mean DS Olaf gets to cancel one of Penny's fog-rain days for free, but I'm fine with that:
It'd be kind of annoying to make the implementation more complex to handle that case properly (and then I'd have to reexamine the cases above...).
~It's not actually a clear-cut advantage for Penny to reinstate fog for a single turn when Olaf's rain runs out - she would end up having a fog-turn right after Olaf's non-fog turn.~ Nevermind, I did my math wrong: The sequence is Penny/Rain, Olaf/Snow, P/S, O/S, P/S, O/R, which totals to 3 full days. The point that it's a niche inter-game interaction that'd take a lot of effort stays, though.

I guess one could argue that Penny should still get the primary use of her rain. If people thought that was important, I'd probably just add a clause of "activates fog for a turn if the COU is in `SMOKE` at turn start".
That would technically be very weird jank, but would solve this case in the most advantageous way for Penny - she would get an un-fogged turn (in DoR-style fog but not Trilogy, lol), while Olaf would have to cope with fog as normal, much like the COP activation turn.
This would also have the effect that any localized source of permanent `SMOKE` would let Penny turn fog on globally forever, which is funny.